### PR TITLE
Address test failure on some systems

### DIFF
--- a/test/nerves_hub/integration/websocket_test.exs
+++ b/test/nerves_hub/integration/websocket_test.exs
@@ -30,7 +30,10 @@ defmodule NervesHub.Integration.WebsocketTest do
   @proxy_socket_config [
     url: "wss://127.0.0.1:4003/socket/websocket",
     serializer: Jason,
-    extra_headers: [{@serial_header, "device-1234"}]
+    extra_headers: [{@serial_header, "device-1234"}],
+    socket_opts: [
+      server_name_indication: 'nerves-hub'
+    ]
   ]
 
   defmodule ClientSocket do


### PR DESCRIPTION
Why:
* It is good to have robust tests.

This change addresses the need by:
* Adding `server_name_indication` for the `socket_opts` in the
`@proxy_socket_config`.