### PR TITLE
Help the Tenants

### DIFF
--- a/lib/nerves_hub_web/controllers/account_controller.ex
+++ b/lib/nerves_hub_web/controllers/account_controller.ex
@@ -11,7 +11,7 @@ defmodule NervesHubWeb.AccountController do
 
   def create(conn, params) do
     params["user"]
-    |> Accounts.create_tenant()
+    |> Accounts.create_tenant_with_user()
     |> case do
       {:ok, _tenant} ->
         redirect(conn, to: "/")

--- a/test/nerves_hub/accounts/accounts_test.exs
+++ b/test/nerves_hub/accounts/accounts_test.exs
@@ -1,0 +1,46 @@
+defmodule NervesHub.AccountsTest do
+  use NervesHub.DataCase
+
+  alias NervesHub.Repo
+  alias NervesHub.Accounts
+  alias Ecto.Changeset
+
+  @required_tenant_params %{name: "Tenant"}
+
+  test "create_tenant with required params" do
+    {:ok, %Accounts.Tenant{} = result_tenant} = Accounts.create_tenant(@required_tenant_params)
+
+    assert result_tenant.name == @required_tenant_params.name
+  end
+
+  test "create_tenant without required params" do
+    assert {:error, %Changeset{}} = Accounts.create_tenant(%{})
+  end
+
+  test "create_tenant_with_user with valid params" do
+    params = %{
+      name: "Testy McTesterson",
+      tenant_name: "mctesterson.com",
+      email: "testy@mctesterson.com",
+      password: "test_password"
+    }
+
+    target_tenant = %Accounts.Tenant{name: params.tenant_name}
+    {:ok, %Accounts.Tenant{} = result_tenant} = Accounts.create_tenant_with_user(params)
+
+    [user | _] = result_tenant |> Repo.preload(:users) |> Map.get(:users)
+
+    assert result_tenant.name == target_tenant.name
+    assert user.name == params.name
+  end
+
+  test "create_tenant_with_user with missing params" do
+    params = %{
+      name: "Testy McTesterson",
+      email: "testy@mctesterson.com",
+      password: "test_password"
+    }
+
+    assert {:error, %Changeset{}} = Accounts.create_tenant_with_user(params)
+  end
+end


### PR DESCRIPTION
Why:

* `create_tenant` function in `accounts.ex` had outgrown itself.
* Needed old (typical) functionality of `create_tenant`

This change addresses the need by:

* moving existing `create_tenant` to `create_tenant_with_user`.
  * changing the (only) call to `create_tenant` to match.
* re-implementing typical `create_tenant`.
* Testing functionality around creating tenants.

Caveats:
* No controller tests.
* Could still use some more tests for `accounts.ex` in the new `accounts_test.exs`