### PR TITLE
Device,Deployment tests and fixtures

### DIFF
--- a/lib/nerves_hub/deployments/deployment.ex
+++ b/lib/nerves_hub/deployments/deployment.ex
@@ -8,6 +8,8 @@ defmodule NervesHub.Deployments.Deployment do
   alias __MODULE__
 
   @type t :: %__MODULE__{}
+  @required_fields [:tenant_id, :firmware_id, :name, :conditions, :is_active]
+  @optional_fields []
 
   schema "deployments" do
     belongs_to(:tenant, Tenant)
@@ -21,16 +23,9 @@ defmodule NervesHub.Deployments.Deployment do
   end
 
   def changeset(%Deployment{} = deployment, params) do
-    fields = [
-      :name,
-      :conditions,
-      :is_active,
-      :firmware_id
-    ]
-
     deployment
-    |> cast(params, fields)
-    |> validate_required(fields)
+    |> cast(params, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
     |> validate_change(:conditions, fn :conditions, conditions ->
       types = %{tags: {:array, :string}, version: :string}
 

--- a/lib/nerves_hub/deployments/deployments.ex
+++ b/lib/nerves_hub/deployments/deployments.ex
@@ -41,21 +41,6 @@ defmodule NervesHub.Deployments do
     |> Repo.insert()
   end
 
-  @spec create_deployment_with_tenant(Tenant.t(), map) ::
-          {:ok, Deployment.t()} | {:error, Changeset.t()}
-  def create_deployment_with_tenant(tenant, params) do
-    params = Map.put(params, :is_active, false)
-
-    deployment =
-      tenant
-      |> Ecto.build_assoc(:deployments)
-
-    deployment
-    |> Map.from_struct()
-    |> Map.merge(params)
-    |> create_deployment()
-  end
-
   @spec toggle_is_active(Deployment.t()) :: {:ok, Deployment.t()} | {:error, Changeset.t()}
   def toggle_is_active(%Deployment{} = deployment) do
     deployment

--- a/lib/nerves_hub/deployments/deployments.ex
+++ b/lib/nerves_hub/deployments/deployments.ex
@@ -34,14 +34,26 @@ defmodule NervesHub.Deployments do
     end
   end
 
-  @spec create_deployment(Tenant.t(), map) :: {:ok, Deployment.t()} | {:error, Changeset.t()}
-  def create_deployment(tenant, params) do
-    params = Map.put(params, "is_active", false)
-
-    tenant
-    |> Ecto.build_assoc(:deployments)
+  @spec create_deployment(map) :: {:ok, Deployment.t()} | {:error, Changeset.t()}
+  def create_deployment(params) do
+    %Deployment{}
     |> Deployment.changeset(params)
     |> Repo.insert()
+  end
+
+  @spec create_deployment_with_tenant(Tenant.t(), map) ::
+          {:ok, Deployment.t()} | {:error, Changeset.t()}
+  def create_deployment_with_tenant(tenant, params) do
+    params = Map.put(params, :is_active, false)
+
+    deployment =
+      tenant
+      |> Ecto.build_assoc(:deployments)
+
+    deployment
+    |> Map.from_struct()
+    |> Map.merge(params)
+    |> create_deployment()
   end
 
   @spec toggle_is_active(Deployment.t()) :: {:ok, Deployment.t()} | {:error, Changeset.t()}

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -7,6 +7,15 @@ defmodule NervesHub.Devices.Device do
   alias __MODULE__
 
   @type t :: %__MODULE__{}
+  @optional_params [
+    :current_version,
+    :target_version,
+    :last_communication,
+    :description,
+    :product,
+    :tags
+  ]
+  @required_params [:tenant_id, :identifier, :architecture, :platform]
 
   schema "devices" do
     belongs_to(:tenant, Tenant)
@@ -26,8 +35,8 @@ defmodule NervesHub.Devices.Device do
 
   def creation_changeset(%Device{} = device, params) do
     device
-    |> cast(params, [:identifier, :description, :tags, :architecture, :platform])
-    |> validate_required([:identifier, :tags, :architecture, :platform])
+    |> cast(params, @required_params ++ @optional_params)
+    |> validate_required(@required_params)
     |> validate_length(:tags, min: 1)
     |> unique_constraint(:identifier, name: :devices_tenant_id_identifier_index)
   end

--- a/lib/nerves_hub/devices/devices.ex
+++ b/lib/nerves_hub/devices/devices.ex
@@ -50,20 +50,6 @@ defmodule NervesHub.Devices do
     |> Repo.insert()
   end
 
-  @spec create_device_with_tenant(Tenant.t(), map) ::
-          {:ok, Device.t()}
-          | {:error, Changeset.t()}
-  def create_device_with_tenant(%Tenant{} = tenant, params) do
-    device =
-      tenant
-      |> Ecto.build_assoc(:devices)
-
-    device
-    |> Map.from_struct()
-    |> Map.merge(params)
-    |> create_device()
-  end
-
   def update_device(%Device{} = device, params) do
     device
     |> Device.update_changeset(params)

--- a/lib/nerves_hub/devices/devices.ex
+++ b/lib/nerves_hub/devices/devices.ex
@@ -41,14 +41,27 @@ defmodule NervesHub.Devices do
     end
   end
 
-  @spec create_device(Tenant.t(), map) ::
+  @spec create_device(map) ::
           {:ok, Device.t()}
           | {:error, Changeset.t()}
-  def create_device(%Tenant{} = tenant, params) do
-    tenant
-    |> Ecto.build_assoc(:devices)
+  def create_device(params) do
+    %Device{}
     |> Device.creation_changeset(params)
     |> Repo.insert()
+  end
+
+  @spec create_device_with_tenant(Tenant.t(), map) ::
+          {:ok, Device.t()}
+          | {:error, Changeset.t()}
+  def create_device_with_tenant(%Tenant{} = tenant, params) do
+    device =
+      tenant
+      |> Ecto.build_assoc(:devices)
+
+    device
+    |> Map.from_struct()
+    |> Map.merge(params)
+    |> create_device()
   end
 
   def update_device(%Device{} = device, params) do

--- a/lib/nerves_hub_web/controllers/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_controller.ex
@@ -74,7 +74,7 @@ defmodule NervesHubWeb.DeploymentController do
               |> MapSet.to_list()
           })
 
-        result = Deployments.create_deployment(tenant, params)
+        result = Deployments.create_deployment_with_tenant(tenant, params)
 
         {firmware, result}
 

--- a/lib/nerves_hub_web/controllers/deployment_controller.ex
+++ b/lib/nerves_hub_web/controllers/deployment_controller.ex
@@ -65,6 +65,8 @@ defmodule NervesHubWeb.DeploymentController do
       {:ok, firmware} ->
         params =
           params
+          |> Map.put("tenant_id", tenant.id)
+          |> Map.put("is_active", false)
           |> Map.put("conditions", %{
             "version" => params["version"],
             "tags" =>
@@ -74,7 +76,7 @@ defmodule NervesHubWeb.DeploymentController do
               |> MapSet.to_list()
           })
 
-        result = Deployments.create_deployment_with_tenant(tenant, params)
+        result = Deployments.create_deployment(params)
 
         {firmware, result}
 

--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -23,11 +23,11 @@ defmodule NervesHubWeb.DeviceController do
     )
   end
 
-  def create(conn, %{"device" => params}) do
-    device_params = tags_to_list(params)
-
-    conn.assigns.tenant
-    |> Devices.create_device_with_tenant(device_params)
+  def create(%{assigns: %{tenant: tenant}} = conn, %{"device" => params}) do
+    params
+    |> tags_to_list()
+    |> Map.put("tenant_id", tenant.id)
+    |> Devices.create_device()
     |> case do
       {:ok, _device} ->
         conn

--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -27,7 +27,7 @@ defmodule NervesHubWeb.DeviceController do
     device_params = tags_to_list(params)
 
     conn.assigns.tenant
-    |> Devices.create_device(device_params)
+    |> Devices.create_device_with_tenant(device_params)
     |> case do
       {:ok, _device} ->
         conn

--- a/test/nerves_hub/deployments/deployments_test.exs
+++ b/test/nerves_hub/deployments/deployments_test.exs
@@ -44,43 +44,4 @@ defmodule NervesHub.DeploymentsTest do
 
     assert {:error, %Changeset{}} = Deployments.create_deployment(params)
   end
-
-  test 'create_deployment_with_tenant with valid parameters', %{
-    tenant: tenant,
-    firmware: firmware
-  } do
-    params = %{
-      firmware_id: firmware.id,
-      name: "my deployment",
-      conditions: %{
-        "version" => "< 1.0.0",
-        "tags" => ["beta", "beta-edge"]
-      },
-      is_active: true
-    }
-
-    {:ok, %Deployments.Deployment{} = deployment} =
-      Deployments.create_deployment_with_tenant(tenant, params)
-
-    for key <- [:firmware_id, :name, :conditions] do
-      assert Map.get(deployment, key) == Map.get(params, key)
-    end
-
-    refute deployment.is_active
-  end
-
-  test 'create_deployment_with_tenant with invalid parameters', %{
-    tenant: tenant
-  } do
-    params = %{
-      name: "my deployment",
-      conditions: %{
-        "version" => "< 1.0.0",
-        "tags" => ["beta", "beta-edge"]
-      },
-      is_active: true
-    }
-
-    {:error, %Changeset{}} = Deployments.create_deployment_with_tenant(tenant, params)
-  end
 end

--- a/test/nerves_hub/deployments/deployments_test.exs
+++ b/test/nerves_hub/deployments/deployments_test.exs
@@ -1,0 +1,86 @@
+defmodule NervesHub.DeploymentsTest do
+  use NervesHub.DataCase
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Deployments
+  alias Ecto.Changeset
+
+  setup do
+    tenant = Fixtures.tenant_fixture()
+    firmware = Fixtures.firmware_fixture(tenant)
+    deployment = Fixtures.deployment_fixture(tenant, firmware)
+
+    {:ok, %{tenant: tenant, firmware: firmware, deployment: deployment}}
+  end
+
+  test 'create_deployment with valid parameters', %{tenant: tenant, firmware: firmware} do
+    params = %{
+      tenant_id: tenant.id,
+      firmware_id: firmware.id,
+      name: "my deployment",
+      conditions: %{
+        "version" => "< 1.0.0",
+        "tags" => ["beta", "beta-edge"]
+      },
+      is_active: true
+    }
+
+    {:ok, %Deployments.Deployment{} = deployment} = Deployments.create_deployment(params)
+
+    for key <- Map.keys(params) do
+      assert Map.get(deployment, key) == Map.get(params, key)
+    end
+  end
+
+  test 'create_deployment with invalid parameters' do
+    params = %{
+      name: "my deployment",
+      conditions: %{
+        "version" => "< 1.0.0",
+        "tags" => ["beta", "beta-edge"]
+      },
+      is_active: true
+    }
+
+    assert {:error, %Changeset{}} = Deployments.create_deployment(params)
+  end
+
+  test 'create_deployment_with_tenant with valid parameters', %{
+    tenant: tenant,
+    firmware: firmware
+  } do
+    params = %{
+      firmware_id: firmware.id,
+      name: "my deployment",
+      conditions: %{
+        "version" => "< 1.0.0",
+        "tags" => ["beta", "beta-edge"]
+      },
+      is_active: true
+    }
+
+    {:ok, %Deployments.Deployment{} = deployment} =
+      Deployments.create_deployment_with_tenant(tenant, params)
+
+    for key <- [:firmware_id, :name, :conditions] do
+      assert Map.get(deployment, key) == Map.get(params, key)
+    end
+
+    refute deployment.is_active
+  end
+
+  test 'create_deployment_with_tenant with invalid parameters', %{
+    tenant: tenant
+  } do
+    params = %{
+      name: "my deployment",
+      conditions: %{
+        "version" => "< 1.0.0",
+        "tags" => ["beta", "beta-edge"]
+      },
+      is_active: true
+    }
+
+    {:error, %Changeset{}} = Deployments.create_deployment_with_tenant(tenant, params)
+  end
+end

--- a/test/nerves_hub/devices/devices_test.exs
+++ b/test/nerves_hub/devices/devices_test.exs
@@ -1,0 +1,74 @@
+defmodule NervesHub.DevicesTest do
+  use NervesHub.DataCase
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Devices
+  alias Ecto.Changeset
+
+  setup do
+    tenant = Fixtures.tenant_fixture()
+    firmware = Fixtures.firmware_fixture(tenant)
+    deployment = Fixtures.deployment_fixture(tenant, firmware)
+    device = Fixtures.device_fixture(tenant, firmware, deployment)
+
+    {:ok, %{tenant: tenant, firmware: firmware, deployment: deployment, device: device}}
+  end
+
+  test 'create_device with valid parameters', %{tenant: tenant, firmware: firmware} do
+    params = %{
+      tenant_id: tenant.id,
+      identifier: "valid identifier",
+      architecture: firmware.architecture,
+      platform: firmware.platform
+    }
+
+    {:ok, %Devices.Device{} = device} = Devices.create_device(params)
+
+    for key <- Map.keys(params) do
+      assert Map.get(device, key) == Map.get(params, key)
+    end
+  end
+
+  test 'create_device with invalid parameters', %{firmware: firmware} do
+    params = %{
+      identifier: "valid identifier",
+      architecture: firmware.architecture,
+      platform: firmware.platform
+    }
+
+    assert {:error, %Changeset{}} = Devices.create_device(params)
+  end
+
+  test 'create_device_with_tenant with valid parameters', %{tenant: tenant, firmware: firmware} do
+    params = %{
+      identifier: "valid identifier",
+      architecture: firmware.architecture,
+      platform: firmware.platform
+    }
+
+    {:ok, %Devices.Device{} = device} = Devices.create_device_with_tenant(tenant, params)
+    assert device.tenant_id == tenant.id
+
+    for key <- Map.keys(params) do
+      assert Map.get(device, key) == Map.get(params, key)
+    end
+  end
+
+  test 'create_device_with_tenant with invalid parameters', %{tenant: tenant, firmware: firmware} do
+    params = %{
+      identifier: 1,
+      architecture: firmware.architecture,
+      platform: firmware.platform
+    }
+
+    assert {:error, %Changeset{}} = Devices.create_device_with_tenant(tenant, params)
+  end
+
+  test 'get_device_by_identifier with existing device', %{device: target_device} do
+    assert {:ok, ^target_device} = Devices.get_device_by_identifier(target_device.identifier)
+  end
+
+  test 'get_device_by_identifier without existing device' do
+    assert {:error, :not_found} = Devices.get_device_by_identifier("non existing identifier")
+  end
+end

--- a/test/nerves_hub/devices/devices_test.exs
+++ b/test/nerves_hub/devices/devices_test.exs
@@ -39,31 +39,6 @@ defmodule NervesHub.DevicesTest do
     assert {:error, %Changeset{}} = Devices.create_device(params)
   end
 
-  test 'create_device_with_tenant with valid parameters', %{tenant: tenant, firmware: firmware} do
-    params = %{
-      identifier: "valid identifier",
-      architecture: firmware.architecture,
-      platform: firmware.platform
-    }
-
-    {:ok, %Devices.Device{} = device} = Devices.create_device_with_tenant(tenant, params)
-    assert device.tenant_id == tenant.id
-
-    for key <- Map.keys(params) do
-      assert Map.get(device, key) == Map.get(params, key)
-    end
-  end
-
-  test 'create_device_with_tenant with invalid parameters', %{tenant: tenant, firmware: firmware} do
-    params = %{
-      identifier: 1,
-      architecture: firmware.architecture,
-      platform: firmware.platform
-    }
-
-    assert {:error, %Changeset{}} = Devices.create_device_with_tenant(tenant, params)
-  end
-
   test 'get_device_by_identifier with existing device', %{device: target_device} do
     assert {:ok, ^target_device} = Devices.get_device_by_identifier(target_device.identifier)
   end

--- a/test/nerves_hub/firmwares/firmwares_test.exs
+++ b/test/nerves_hub/firmwares/firmwares_test.exs
@@ -1,52 +1,17 @@
 defmodule NervesHub.FirmwaresTest do
   use NervesHub.DataCase
 
-  alias NervesHub.Repo
+  alias NervesHub.{Firmwares, Fixtures, Repo}
   alias NervesHub.Firmwares.Firmware
-  alias NervesHub.Firmwares
   alias NervesHub.Deployments.Deployment
-  alias NervesHub.Accounts.Tenant
-  alias NervesHub.Devices.Device
   alias Ecto.Changeset
 
   setup do
-    tenant =
-      %Tenant{name: "Test Tenant"}
-      |> Repo.insert!()
+    tenant = Fixtures.tenant_fixture()
+    firmware = Fixtures.firmware_fixture(tenant)
+    deployment = Fixtures.deployment_fixture(tenant, firmware)
 
-    firmware =
-      %Firmware{
-        tenant_id: tenant.id,
-        version: "1.0.0",
-        product: "test_product",
-        architecture: "arm",
-        platform: "rpi0",
-        upload_metadata: %{"public_url" => "http://example.com"},
-        timestamp: DateTime.utc_now(),
-        signed: true,
-        metadata: ""
-      }
-      |> Repo.insert!()
-
-    deployment =
-      %Deployment{
-        tenant_id: tenant.id,
-        firmware_id: firmware.id,
-        name: "Test Deployment",
-        conditions: %{
-          "version" => "< 1.0.0",
-          "tags" => ["beta", "beta-edge"]
-        },
-        is_active: true
-      }
-      |> Repo.insert!()
-
-    device = %Device{
-      tenant_id: tenant.id,
-      architecture: firmware.architecture,
-      platform: firmware.platform,
-      tags: deployment.conditions["tags"]
-    }
+    device = Fixtures.device_fixture(tenant, firmware, deployment)
 
     {:ok,
      %{

--- a/test/nerves_hub_web/controllers/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_controller_test.exs
@@ -1,0 +1,57 @@
+defmodule NervesHubWeb.DeploymentControllerTest do
+  use NervesHubWeb.ConnCase.Browser
+
+  alias NervesHub.Fixtures
+
+  describe "index" do
+    test "lists all deployments", %{conn: conn} do
+      conn = get(conn, deployment_path(conn, :index))
+      assert html_response(conn, 200) =~ "Deployments"
+    end
+  end
+
+  describe "new deployment" do
+    test "renders form with valid request params", %{conn: conn, current_tenant: tenant} do
+      firmware = Fixtures.firmware_fixture(tenant)
+      conn = get(conn, deployment_path(conn, :new), deployment: %{firmware_id: firmware.id})
+
+      assert html_response(conn, 200) =~ "Create Deployment"
+    end
+
+    test "redirects with invalid firmware", %{conn: conn} do
+      conn = get(conn, deployment_path(conn, :new), deployment: %{firmware_id: -1})
+
+      assert redirected_to(conn, 302) =~ deployment_path(conn, :new)
+    end
+
+    test "redirects form with no firmware", %{conn: conn} do
+      conn = get(conn, deployment_path(conn, :new))
+
+      assert redirected_to(conn, 302) =~ firmware_path(conn, :index)
+    end
+  end
+
+  describe "create deployment" do
+    test "redirects to index when data is valid", %{conn: conn, current_tenant: tenant} do
+      firmware = Fixtures.firmware_fixture(tenant)
+
+      deployment_params = %{
+        firmware_id: firmware.id,
+        tenant_id: tenant.id,
+        name: "Test Deployment ABC",
+        tags: "beta, beta-edge",
+        version: "< 1.0.0",
+        is_active: true
+      }
+
+      # check that we end up in the right place
+      create_conn = post(conn, deployment_path(conn, :create), deployment: deployment_params)
+      assert redirected_to(create_conn, 302) =~ deployment_path(conn, :index)
+
+      # check that the proper creation side effects took place
+      conn = get(conn, deployment_path(conn, :index))
+      assert html_response(conn, 200) =~ deployment_params.name
+      assert html_response(conn, 200) =~ "Inactive"
+    end
+  end
+end

--- a/test/nerves_hub_web/controllers/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/device_controller_test.exs
@@ -1,0 +1,43 @@
+defmodule NervesHubWeb.DeviceControllerTest do
+  use NervesHubWeb.ConnCase.Browser
+
+  alias NervesHub.Fixtures
+
+  describe "index" do
+    test "lists all devices", %{conn: conn} do
+      conn = get(conn, device_path(conn, :index))
+      assert html_response(conn, 200) =~ "Devices"
+    end
+  end
+
+  describe "new device" do
+    test "renders form with valid request params", %{conn: conn} do
+      conn = get(conn, device_path(conn, :new))
+
+      assert html_response(conn, 200) =~ "Create a Device"
+    end
+  end
+
+  describe "create device" do
+    test "redirects to show when data is valid", %{conn: conn, current_tenant: tenant} do
+      firmware = Fixtures.firmware_fixture(tenant)
+
+      device_params = %{
+        # firmware_id: firmware.id,
+        # tenant_id: tenant.id,
+        architecture: firmware.architecture,
+        platform: firmware.platform,
+        identifier: "device_identifier",
+        tags: "beta, beta-edge"
+      }
+
+      # check that we end up in the right place
+      create_conn = post(conn, device_path(conn, :create), device: device_params)
+      assert redirected_to(create_conn, 302) =~ device_path(conn, :index)
+
+      # check that the proper creation side effects took place
+      conn = get(conn, device_path(conn, :index))
+      assert html_response(conn, 200) =~ device_params.identifier
+    end
+  end
+end

--- a/test/support/browser_case.ex
+++ b/test/support/browser_case.ex
@@ -1,0 +1,32 @@
+defmodule NervesHubWeb.ConnCase.Browser do
+  @moduledoc """
+  conn case for browser related tests
+  """
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      use NervesHubWeb.ConnCase
+      import Plug.Test
+
+      setup do
+        {:ok, tenant} = NervesHub.Accounts.create_tenant(%{name: "Browser Tenant"})
+
+        {:ok, default_user} =
+          tenant
+          |> NervesHub.Accounts.create_user(%{
+            name: "Browser User",
+            email: "user@browser.com",
+            password: "password"
+          })
+
+        conn =
+          build_conn()
+          |> Map.put(:assigns, %{tenant: tenant})
+          |> init_test_session(%{"auth_user_id" => default_user.id})
+
+        %{conn: conn, current_user: default_user, current_tenant: tenant}
+      end
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,0 +1,81 @@
+defmodule NervesHub.Fixtures do
+  alias NervesHub.Repo
+  alias NervesHub.Accounts
+  alias NervesHub.Devices
+  alias NervesHub.Deployments
+  alias NervesHub.Firmwares
+
+  @tenant_params %{name: "Test Tenant"}
+  @firmware_params %{
+    version: "1.0.0",
+    product: "test_product",
+    architecture: "arm",
+    platform: "rpi0",
+    upload_metadata: %{"public_url" => "http://example.com"},
+    timestamp: DateTime.utc_now(),
+    signed: true,
+    metadata: "not blank"
+  }
+  @deployment_params %{
+    name: "Test Deployment",
+    conditions: %{
+      "version" => "< 1.0.0",
+      "tags" => ["beta", "beta-edge"]
+    },
+    is_active: true
+  }
+  @device_params %{identifier: "device-1234"}
+
+  def tenant_fixture(params \\ %{}) do
+    {:ok, tenant} =
+      params
+      |> Enum.into(@tenant_params)
+      |> Accounts.create_tenant()
+
+    tenant
+  end
+
+  def firmware_fixture(%Accounts.Tenant{} = tenant, params \\ %{}) do
+    {:ok, firmware} =
+      %{tenant_id: tenant.id}
+      |> Enum.into(params)
+      |> Enum.into(@firmware_params)
+      |> Firmwares.create_firmware()
+
+    firmware
+  end
+
+  def deployment_fixture(
+        %Accounts.Tenant{} = tenant,
+        %Firmwares.Firmware{} = firmware,
+        params \\ %{}
+      ) do
+    {:ok, deployment} =
+      %{tenant_id: tenant.id, firmware_id: firmware.id}
+      |> Enum.into(params)
+      |> Enum.into(@deployment_params)
+      |> Deployments.create_deployment()
+
+    deployment
+  end
+
+  def device_fixture(
+        %Accounts.Tenant{} = tenant,
+        %Firmwares.Firmware{} = firmware,
+        %Deployments.Deployment{} = deployment,
+        params \\ %{}
+      ) do
+    {:ok, device} =
+      %{
+        tenant_id: tenant.id,
+        architecture: firmware.architecture,
+        platform: firmware.platform,
+        tags: deployment.conditions["tags"]
+      }
+      |> Enum.into(params)
+      |> Enum.into(@device_params)
+      |> Devices.create_device()
+
+    device
+  end
+end


### PR DESCRIPTION
Why:
* I will feel more confident developing upcoming features if there are
tests for the underlying functionality.

This change addresses the need by:
* `deployments_test.exs`, minor refactoring of `deployments.ex` and
`deployment.ex`, and updating `deployment_controller.ex` to match.
* `devices_test.exs`, minor refactoring of `devices.ex` and
`device.ex`, and updating `devices_controller.ex` to match.
* fixtures in `test/support/fixtures.ex`

Other Notes:
* I only added test coverage for functions that would directly impact my
upcoming feature(s).  In order to improve overall test coverage without
sacrifing velocity entirely, I will continue to follow this pattern in
the future.