### PR TITLE
Device Channel checks for firmware update on join

### DIFF
--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -33,18 +33,11 @@ defmodule NervesHub.Devices.Device do
     timestamps()
   end
 
-  def creation_changeset(%Device{} = device, params) do
+  def changeset(%Device{} = device, params) do
     device
     |> cast(params, @required_params ++ @optional_params)
     |> validate_required(@required_params)
     |> validate_length(:tags, min: 1)
     |> unique_constraint(:identifier, name: :devices_tenant_id_identifier_index)
-  end
-
-  def update_changeset(%Device{} = device, params) do
-    device
-    |> cast(params, [:tags])
-    |> validate_required([:tags])
-    |> validate_length(:tags, min: 1)
   end
 end

--- a/lib/nerves_hub/devices/devices.ex
+++ b/lib/nerves_hub/devices/devices.ex
@@ -46,13 +46,13 @@ defmodule NervesHub.Devices do
           | {:error, Changeset.t()}
   def create_device(params) do
     %Device{}
-    |> Device.creation_changeset(params)
+    |> Device.changeset(params)
     |> Repo.insert()
   end
 
   def update_device(%Device{} = device, params) do
     device
-    |> Device.update_changeset(params)
+    |> Device.changeset(params)
     |> Repo.update()
   end
 end

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -1,12 +1,56 @@
 defmodule NervesHubWeb.DeviceChannel do
   use NervesHubWeb, :channel
+  alias NervesHub.Devices
 
-  def join("device:" <> serial, _payload, socket) do
+  def join("device:" <> serial, payload, socket) do
     if authorized?(socket, serial) do
-      {:ok, %{serial: serial}, socket}
+      with {:ok, message} <- build_message(serial, payload) do
+        {:ok, message, socket}
+      else
+        {:error, reply} -> {:error, reply}
+      end
     else
       {:error, %{reason: "unauthorized"}}
     end
+  end
+
+  defp build_message(serial, payload) do
+    with {:ok, device} <- db_operations(serial, payload) do
+      {:ok, %{}}
+      |> update_message(device, device.current_version)
+    else
+      {:error, message} -> {:error, %{reason: message}}
+      _ -> {:error, %{reason: :unknown_error}}
+    end
+  end
+
+  defp db_operations(serial, payload) do
+    serial_check(serial)
+    |> device_update(payload)
+  end
+
+  defp serial_check(serial) do
+    with {:ok, device} <- Devices.get_device_by_identifier(serial) do
+      {:ok, device}
+    else
+      _ -> {:error, :unauthorized}
+    end
+  end
+
+  defp device_update({:error, message}, _), do: {:error, message}
+
+  defp device_update({:ok, device}, %{"version" => version}) do
+    Devices.update_device(device, %{current_version: version})
+  end
+
+  defp device_update(_, _), do: {:error, :no_firmware_version}
+
+  defp update_message({:ok, %{} = message}, %Devices.Device{target_version: version}, version) do
+    {:ok, %{update_available: false} |> Map.merge(message)}
+  end
+
+  defp update_message({:ok, %{} = message}, _, _) do
+    {:ok, %{update_available: true} |> Map.merge(message)}
   end
 
   # Channels can be used in a request/response fashion

--- a/lib/nerves_hub_web/controllers/device_controller.ex
+++ b/lib/nerves_hub_web/controllers/device_controller.ex
@@ -43,7 +43,7 @@ defmodule NervesHubWeb.DeviceController do
     conn
     |> render(
       "edit.html",
-      changeset: conn.assigns.device |> Device.update_changeset(%{}) |> tags_to_string()
+      changeset: conn.assigns.device |> Device.changeset(%{}) |> tags_to_string()
     )
   end
 

--- a/test/nerves_hub/integration/websocket_test.exs
+++ b/test/nerves_hub/integration/websocket_test.exs
@@ -1,5 +1,8 @@
 defmodule NervesHub.Integration.WebsocketTest do
   use ExUnit.Case, async: false
+  use NervesHubWeb.ChannelCase
+  alias NervesHub.Fixtures
+  alias NervesHub.Devices
 
   @serial_header Application.get_env(:nerves_hub, :device_serial_header)
   @valid_serial "device-1234"
@@ -37,6 +40,13 @@ defmodule NervesHub.Integration.WebsocketTest do
     ]
   ]
 
+  def device_fixture(device_params \\ %{}) do
+    tenant = Fixtures.tenant_fixture()
+    firmware = Fixtures.firmware_fixture(tenant)
+    deployment = Fixtures.deployment_fixture(tenant, firmware)
+    Fixtures.device_fixture(tenant, firmware, deployment, device_params)
+  end
+
   defmodule ClientSocket do
     use PhoenixChannelClient.Socket
 
@@ -66,87 +76,187 @@ defmodule NervesHub.Integration.WebsocketTest do
     end
   end
 
-  test "Can connect and authenticate to channel using client ssl certificate" do
-    opts =
-      @ssl_socket_config
-      |> Keyword.put(:caller, self())
+  describe "socket auth" do
+    test "Can connect and authenticate to channel using client ssl certificate" do
+      device =
+        %{identifier: @valid_serial}
+        |> device_fixture()
 
-    {:ok, _} = ClientSocket.start_link(opts)
+      opts =
+        @ssl_socket_config
+        |> Keyword.put(:caller, self())
 
-    {:ok, _channel} =
-      ClientChannel.start_link(
-        socket: ClientSocket,
-        topic: "device:#{@valid_serial}",
-        caller: self()
+      {:ok, _} = ClientSocket.start_link(opts)
+
+      {:ok, _channel} =
+        ClientChannel.start_link(
+          socket: ClientSocket,
+          topic: "device:#{device.identifier}",
+          caller: self()
+        )
+
+      ClientChannel.join(%{"version" => "0.0.1"})
+
+      assert_receive(
+        {:ok, :join, %{"response" => %{}, "status" => "ok"}, _ref},
+        1_000
       )
+    end
 
-    ClientChannel.join()
+    test "authentication rejected to channel using incorrect client ssl certificate" do
+      opts =
+        @fake_ssl_socket_config
+        |> Keyword.put(:caller, self())
 
-    assert_receive(
-      {:ok, :join, %{"response" => %{"serial" => @valid_serial}, "status" => "ok"}, _ref},
-      1_000
-    )
+      {:ok, _} = ClientSocket.start_link(opts)
+
+      {:ok, _channel} =
+        ClientChannel.start_link(
+          socket: ClientSocket,
+          topic: "device:#{@valid_serial}",
+          caller: self()
+        )
+
+      ClientChannel.join()
+      assert_receive({:socket_closed, {:tls_alert, 'unknown ca'}}, 1_000)
+    end
+
+    test "Can connect and authenticate to channel using proxy headers" do
+      device = device_fixture()
+
+      opts =
+        @proxy_socket_config
+        |> Keyword.put(:caller, self())
+
+      {:ok, _} = ClientSocket.start_link(opts)
+
+      {:ok, _channel} =
+        ClientChannel.start_link(
+          socket: ClientSocket,
+          topic: "device:#{device.identifier}",
+          caller: self()
+        )
+
+      ClientChannel.join(%{"version" => "0.1.1"})
+
+      assert_receive(
+        {:ok, :join, %{"response" => %{}, "status" => "ok"}, _ref},
+        1_000
+      )
+    end
   end
 
-  test "Cannot connect and authenticate to channel with non-matching serial" do
-    opts =
-      @ssl_socket_config
-      |> Keyword.put(:caller, self())
+  describe "channel auth" do
+    test "Cannot connect and authenticate to channel with non-matching serial" do
+      opts =
+        @ssl_socket_config
+        |> Keyword.put(:caller, self())
 
-    {:ok, _} = ClientSocket.start_link(opts)
+      {:ok, _} = ClientSocket.start_link(opts)
 
-    {:ok, _channel} =
-      ClientChannel.start_link(
-        socket: ClientSocket,
-        topic: "device:not_valid_serial",
-        caller: self()
+      {:ok, _channel} =
+        ClientChannel.start_link(
+          socket: ClientSocket,
+          topic: "device:not_valid_serial",
+          caller: self()
+        )
+
+      ClientChannel.join()
+
+      assert_receive(
+        {:error, :join, %{"response" => %{"reason" => "unauthorized"}, "status" => "error"},
+         _ref},
+        1_000
       )
+    end
 
-    ClientChannel.join()
+    test "Cannot connect and authenticate to channel with non-existing serial" do
+      opts =
+        @ssl_socket_config
+        |> Keyword.put(:caller, self())
 
-    assert_receive(
-      {:error, :join, %{"response" => %{"reason" => "unauthorized"}, "status" => "error"}, _ref},
-      1_000
-    )
+      {:ok, _} = ClientSocket.start_link(opts)
+
+      {:ok, _channel} =
+        ClientChannel.start_link(
+          socket: ClientSocket,
+          topic: "device:#{@valid_serial}",
+          caller: self()
+        )
+
+      ClientChannel.join()
+
+      assert_receive(
+        {:error, :join, %{"response" => %{"reason" => "unauthorized"}, "status" => "error"},
+         _ref},
+        1_000
+      )
+    end
   end
 
-  test "authentication rejected to channel using incorrect client ssl certificate" do
-    opts =
-      @fake_ssl_socket_config
-      |> Keyword.put(:caller, self())
+  describe "firmware update" do
+    test "receives update message when current_version does not match target_version" do
+      device =
+        %{identifier: @valid_serial, current_version: "a", target_version: "b"}
+        |> device_fixture()
 
-    {:ok, _} = ClientSocket.start_link(opts)
+      opts =
+        @ssl_socket_config
+        |> Keyword.put(:caller, self())
 
-    {:ok, _channel} =
-      ClientChannel.start_link(
-        socket: ClientSocket,
-        topic: "device:#{@valid_serial}",
-        caller: self()
+      {:ok, _} = ClientSocket.start_link(opts)
+
+      {:ok, _channel} =
+        ClientChannel.start_link(
+          socket: ClientSocket,
+          topic: "device:#{device.identifier}",
+          caller: self()
+        )
+
+      ClientChannel.join(%{"version" => device.current_version})
+
+      assert_receive(
+        {:ok, :join,
+         %{
+           "response" => %{"update_available" => true},
+           "status" => "ok"
+         }, _ref},
+        1_000
+      )
+    end
+
+    test "does not receive update message when current_version matches target_version" do
+      device =
+        %{identifier: @valid_serial, current_version: "a", target_version: "b"}
+        |> device_fixture()
+
+      opts =
+        @ssl_socket_config
+        |> Keyword.put(:caller, self())
+
+      {:ok, _} = ClientSocket.start_link(opts)
+
+      {:ok, _channel} =
+        ClientChannel.start_link(
+          socket: ClientSocket,
+          topic: "device:#{device.identifier}",
+          caller: self()
+        )
+
+      ClientChannel.join(%{"version" => device.target_version})
+
+      assert_receive(
+        {:ok, :join,
+         %{
+           "response" => %{"update_available" => false},
+           "status" => "ok"
+         }, _ref},
+        1_000
       )
 
-    ClientChannel.join()
-    assert_receive({:socket_closed, {:tls_alert, 'unknown ca'}}, 1_000)
-  end
+      {:ok, updated_device} = Devices.get_device_by_identifier(device.identifier)
 
-  test "Can connect and authenticate to channel using proxy headers" do
-    opts =
-      @proxy_socket_config
-      |> Keyword.put(:caller, self())
-
-    {:ok, _} = ClientSocket.start_link(opts)
-
-    {:ok, _channel} =
-      ClientChannel.start_link(
-        socket: ClientSocket,
-        topic: "device:#{@valid_serial}",
-        caller: self()
-      )
-
-    ClientChannel.join()
-
-    assert_receive(
-      {:ok, :join, %{"response" => %{"serial" => @valid_serial}, "status" => "ok"}, _ref},
-      1_000
-    )
+      assert updated_device.current_version == device.target_version
+    end
   end
 end


### PR DESCRIPTION
Why:
* We want to know if a device needs new firmware ASAP.
* https://github.com/nerves-hub/nerves_hub/issues/79

This change addresses the need by:
* Checking if `%{"version" => version}` in the join payload matches the
target version in the database, and acting accordingly.
* Also updates the `current_version` in the database to the version that
is reported in the join payload.

Caveats:
* Cannot send out a message with instructions for updating firmware
because that is yet to be implemented.