### PR TITLE
current_firmware and target_deployment for device

### DIFF
--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -2,14 +2,18 @@ defmodule NervesHub.Devices.Device do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query
 
   alias NervesHub.Accounts.Tenant
+  alias NervesHub.Deployments.Deployment
+  alias NervesHub.Firmwares.Firmware
+
   alias __MODULE__
 
   @type t :: %__MODULE__{}
   @optional_params [
-    :current_version,
-    :target_version,
+    :target_deployment_id,
+    :current_firmware_id,
     :last_communication,
     :description,
     :product,
@@ -19,13 +23,13 @@ defmodule NervesHub.Devices.Device do
 
   schema "devices" do
     belongs_to(:tenant, Tenant)
+    belongs_to(:target_deployment, Deployment)
+    belongs_to(:current_firmware, Firmware)
 
     field(:identifier, :string)
     field(:description, :string)
     field(:product, :string)
     field(:platform, :string)
-    field(:current_version, :string)
-    field(:target_version, :string)
     field(:last_communication, :utc_datetime)
     field(:architecture, :string)
     field(:tags, {:array, :string})
@@ -39,5 +43,10 @@ defmodule NervesHub.Devices.Device do
     |> validate_required(@required_params)
     |> validate_length(:tags, min: 1)
     |> unique_constraint(:identifier, name: :devices_tenant_id_identifier_index)
+  end
+
+  def with_deployment(device_query) do
+    device_query
+    |> preload(:target_deployment)
   end
 end

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -49,4 +49,9 @@ defmodule NervesHub.Devices.Device do
     device_query
     |> preload(:target_deployment)
   end
+
+  def with_tenant(device_query) do
+    device_query
+    |> preload(:tenant)
+  end
 end

--- a/lib/nerves_hub/devices/devices.ex
+++ b/lib/nerves_hub/devices/devices.ex
@@ -34,6 +34,7 @@ defmodule NervesHub.Devices do
     query = from(d in Device, where: d.identifier == ^identifier)
 
     query
+    |> Device.with_deployment()
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}

--- a/lib/nerves_hub/devices/devices.ex
+++ b/lib/nerves_hub/devices/devices.ex
@@ -35,6 +35,7 @@ defmodule NervesHub.Devices do
 
     query
     |> Device.with_deployment()
+    |> Device.with_tenant()
     |> Repo.one()
     |> case do
       nil -> {:error, :not_found}

--- a/lib/nerves_hub/firmwares/firmwares.ex
+++ b/lib/nerves_hub/firmwares/firmwares.ex
@@ -28,24 +28,12 @@ defmodule NervesHub.Firmwares do
     end
   end
 
-  @spec get_firmware(integer()) ::
+  @spec get_firmware_by_product_and_version(Tenant.t(), String.t(), String.t()) ::
           {:ok, Firmware.t()}
           | {:error, :not_found}
-  def get_firmware(id) do
+  def get_firmware_by_product_and_version(%Tenant{} = tenant, product, version) do
     Firmware
-    |> Repo.get(id)
-    |> case do
-      nil -> {:error, :not_found}
-      firmware -> {:ok, firmware}
-    end
-  end
-
-  @spec get_firmware_by_tenant_id_product_and_version(integer(), string(), string()) ::
-          {:ok, Firmware.t()}
-          | {:error, :not_found}
-  def get_firmware_by_tenant_id_product_and_version(tenant_id, product, version) do
-    Firmware
-    |> Repo.get_by(tenant_id: tenant_id, product: product, version: version)
+    |> Repo.get_by(tenant_id: tenant.id, product: product, version: version)
     |> case do
       nil -> {:error, :not_found}
       firmware -> {:ok, firmware}

--- a/lib/nerves_hub/firmwares/firmwares.ex
+++ b/lib/nerves_hub/firmwares/firmwares.ex
@@ -28,6 +28,30 @@ defmodule NervesHub.Firmwares do
     end
   end
 
+  @spec get_firmware(integer()) ::
+          {:ok, Firmware.t()}
+          | {:error, :not_found}
+  def get_firmware(id) do
+    Firmware
+    |> Repo.get(id)
+    |> case do
+      nil -> {:error, :not_found}
+      firmware -> {:ok, firmware}
+    end
+  end
+
+  @spec get_firmware_by_tenant_id_product_and_version(integer(), string(), string()) ::
+          {:ok, Firmware.t()}
+          | {:error, :not_found}
+  def get_firmware_by_tenant_id_product_and_version(tenant_id, product, version) do
+    Firmware
+    |> Repo.get_by(tenant_id: tenant_id, product: product, version: version)
+    |> case do
+      nil -> {:error, :not_found}
+      firmware -> {:ok, firmware}
+    end
+  end
+
   @spec create_firmware(map) ::
           {:ok, Firmware.t()}
           | {:error, Changeset.t()}

--- a/lib/nerves_hub_web/channels/device_channel.ex
+++ b/lib/nerves_hub_web/channels/device_channel.ex
@@ -2,12 +2,13 @@ defmodule NervesHubWeb.DeviceChannel do
   use NervesHubWeb, :channel
   alias NervesHub.Devices
   alias NervesHub.Firmwares
+  alias NervesHub.Accounts
 
   @uploader Application.get_env(:nerves_hub, :firmware_upload)
 
   def join("device:" <> serial, payload, socket) do
     if authorized?(socket, serial) do
-      with {:ok, message} <- build_message(serial, payload) do
+      with {:ok, message} <- build_message(socket, payload) do
         {:ok, message, socket}
       else
         {:error, reply} -> {:error, reply}
@@ -17,14 +18,18 @@ defmodule NervesHubWeb.DeviceChannel do
     end
   end
 
-  defp build_message(serial, payload) do
-    with {:ok, device} <- db_operations(serial, payload) do
+  defp build_message(%{assigns: %{device: device, tenant: tenant}}, payload) do
+    with {:ok, device} <- device_update(device, tenant, payload) do
       {:ok, %{}}
-      |> update_message(device, device.current_firmware_id)
+      |> update_message(device, tenant)
     else
       {:error, message} -> {:error, %{reason: message}}
       _ -> {:error, %{reason: :unknown_error}}
     end
+  end
+
+  defp build_message(_, _) do
+    {:error, %{reason: :no_device_or_tenant}}
   end
 
   defp db_operations(serial, payload) do
@@ -32,20 +37,13 @@ defmodule NervesHubWeb.DeviceChannel do
     |> device_update(payload)
   end
 
-  defp serial_check(serial) do
-    with {:ok, device} <- Devices.get_device_by_identifier(serial) do
-      {:ok, device}
-    else
-      _ -> {:error, :unauthorized}
-    end
-  end
-
-  defp device_update({:error, message}, _), do: {:error, message}
-
-  defp device_update({:ok, device}, %{"version" => version, "product" => product}) do
+  defp device_update(%Devices.Device{} = device, %Accounts.Tenant{} = tenant, %{
+         "version" => version,
+         "product" => product
+       }) do
     with {:ok, firmware} <-
-           Firmwares.get_firmware_by_tenant_id_product_and_version(
-             device.tenant_id,
+           Firmwares.get_firmware_by_product_and_version(
+             tenant,
              product,
              version
            ) do
@@ -59,8 +57,11 @@ defmodule NervesHubWeb.DeviceChannel do
 
   defp update_message(
          {:ok, %{} = message},
-         %Devices.Device{target_deployment: %{firmware_id: firmware_id}},
-         firmware_id
+         %Devices.Device{
+           target_deployment: %{firmware_id: firmware_id},
+           current_firmware_id: firmware_id
+         },
+         _
        ) do
     {:ok, %{update_available: false} |> Map.merge(message)}
   end
@@ -68,15 +69,17 @@ defmodule NervesHubWeb.DeviceChannel do
   defp update_message(
          {:ok, %{} = message},
          %Devices.Device{target_deployment: %{firmware_id: firmware_id}},
-         _
+         %Accounts.Tenant{} = tenant
        ) do
-    with {:ok, firmware} <- Firmwares.get_firmware(firmware_id),
+    with {:ok, firmware} <- Firmwares.get_firmware(tenant, firmware_id),
          {:ok, url} <- @uploader.download_file(firmware) do
       {:ok, %{update_available: true, firmware_url: url} |> Map.merge(message)}
     else
       _ -> {:error, :no_firmware_url}
     end
   end
+
+  defp update_message(_, _), do: {:error, :unknown_error}
 
   # Channels can be used in a request/response fashion
   # by sending replies to requests from the client
@@ -92,7 +95,7 @@ defmodule NervesHubWeb.DeviceChannel do
   end
 
   # Add authorization logic here as required.
-  defp authorized?(%{assigns: %{serial: socket_serial}}, socket_serial) do
+  defp authorized?(%{assigns: %{device: %Devices.Device{identifier: identifier}}}, identifier) do
     true
   end
 

--- a/lib/nerves_hub_web/templates/device/edit.html.eex
+++ b/lib/nerves_hub_web/templates/device/edit.html.eex
@@ -12,10 +12,6 @@
     <td><%= @device.description %></td>
   </tr>
   <tr>
-    <th>Current Version</th>
-    <td><%= @device.current_version %></td>
-  </tr>
-  <tr>
     <th>Architecture</th>
     <td><%= @device.architecture %></td>
   </tr>

--- a/lib/nerves_hub_web/templates/device/index.html.eex
+++ b/lib/nerves_hub_web/templates/device/index.html.eex
@@ -21,7 +21,6 @@
     <%= for device <- @devices do %>
       <tr>
         <td><%= device.identifier %></td>
-        <td><%= device.current_version %></td>
         <td>
           <input type="checkbox" disabled>
         </td>

--- a/priv/repo/migrations/20180618171943_device_deployment_id.exs
+++ b/priv/repo/migrations/20180618171943_device_deployment_id.exs
@@ -1,0 +1,21 @@
+defmodule NervesHub.Repo.Migrations.DeviceDeploymentId do
+  use Ecto.Migration
+
+  def up do
+    alter table(:devices) do
+      add(:target_deployment_id, references(:deployments, on_delete: :nothing), null: true)
+      add(:current_firmware_id, references(:firmwares, on_delete: :nothing), null: true)
+
+      remove(:target_version)
+      remove(:current_version)
+    end
+  end
+
+  def down do
+    add(:target_version, :string, null: true)
+    add(:current_version, :string, null: true)
+
+    remove(:target_deployment_id)
+    remove(:current_firmware_id)
+  end
+end

--- a/test/nerves_hub/devices/devices_test.exs
+++ b/test/nerves_hub/devices/devices_test.exs
@@ -41,7 +41,11 @@ defmodule NervesHub.DevicesTest do
   end
 
   test 'get_device_by_identifier with existing device', %{device: target_device} do
-    assert {:ok, ^target_device} = Devices.get_device_by_identifier(target_device.identifier)
+    assert {:ok, result} = Devices.get_device_by_identifier(target_device.identifier)
+
+    for key <- [:tenant_id, :deployment_id, :device_identifier] do
+      assert Map.get(target_device, key) == Map.get(result, key)
+    end
   end
 
   test 'get_device_by_identifier without existing device' do

--- a/test/nerves_hub/integration/websocket_test.exs
+++ b/test/nerves_hub/integration/websocket_test.exs
@@ -177,8 +177,7 @@ defmodule NervesHub.Integration.WebsocketTest do
       ClientChannel.join()
 
       assert_receive(
-        {:error, :join, %{"response" => %{"reason" => "unauthorized"}, "status" => "error"},
-         _ref},
+        {:socket_closed, {403, "Forbidden"}},
         1_000
       )
     end
@@ -200,8 +199,7 @@ defmodule NervesHub.Integration.WebsocketTest do
       ClientChannel.join()
 
       assert_receive(
-        {:error, :join, %{"response" => %{"reason" => "unauthorized"}, "status" => "error"},
-         _ref},
+        {:socket_closed, {403, "Forbidden"}},
         1_000
       )
     end
@@ -216,7 +214,7 @@ defmodule NervesHub.Integration.WebsocketTest do
         |> device_fixture("0.0.2")
 
       tenant = %Accounts.Tenant{id: device.tenant_id}
-      tenant_key = Fixtures.tenant_key_fixture(tenant, %{name: "some other key"})
+      tenant_key = Fixtures.tenant_key_fixture(tenant, %{name: "another key"})
 
       Fixtures.firmware_fixture(tenant, tenant_key, %{
         product: @valid_product,

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -87,6 +87,8 @@ defmodule NervesHub.Fixtures do
     {:ok, device} =
       %{
         tenant_id: tenant.id,
+        target_deployment_id: deployment.id,
+        current_firmware_id: firmware.id,
         architecture: firmware.architecture,
         platform: firmware.platform,
         tags: deployment.conditions["tags"]


### PR DESCRIPTION
Why:

* We want to make it easy to tell if a device needs an update.
* We want to be able to provide a URL when a device needs an update.

This change addresses the need by:

* Migration that adds `:target_deployment` and `:current_firmware` to
`Device`.
* Logic in the `device_channel` which finds the url for an update if it
is available.

Caveats:
* Web views/UI for the new fields need to be worked out.