### PR TITLE
Enable erlang distribution in production

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,7 +18,7 @@ config :nerves_hub, NervesHubWeb.Endpoint,
   server: true,
   url: [host: "www.nerves-hub.org", port: 80],
   secret_key_base: "${SECRET_KEY_BASE}",
-  # force_ssl: [hsts: true],
+  force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # https: [

--- a/rel/Dockerfile.build
+++ b/rel/Dockerfile.build
@@ -25,7 +25,13 @@ ENV \
 RUN apt-get update -qq \
   && apt-get -qq -y install \
     locales \
-    awscli \
+    python \
+    python-dev \
+    python-pip \
+    python-setuptools \
+    jq \
+  && pip install --upgrade awscli \
+  && apt-get clean \
   && export LANG=en_US.UTF-8 \
   && echo $LANG UTF-8 > /etc/locale.gen \
   && locale-gen \
@@ -42,7 +48,14 @@ WORKDIR /app
 COPY --from=builder /build/_build/$MIX_ENV/rel/nerves_hub/releases/*/nerves_hub.tar.gz .
 RUN tar xvfz nerves_hub.tar.gz > /dev/null && rm nerves_hub.tar.gz
 
-COPY --from=builder /build/rel/scripts/s3-entrypoint.sh .
-RUN ["chmod", "+x", "/app/s3-entrypoint.sh"]
+COPY --from=builder /build/rel/scripts/docker-entrypoint.sh .
+COPY --from=builder /build/rel/scripts/s3-sync.sh .
+COPY --from=builder /build/rel/scripts/ecs-cluster.sh .
 
-CMD ["nerves_hub", "foreground"]
+RUN ["chmod", "+x", "/app/docker-entrypoint.sh"]
+RUN ["chmod", "+x", "/app/s3-sync.sh"]
+RUN ["chmod", "+x", "/app/ecs-cluster.sh"]
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
+CMD ["/app/ecs-cluster.sh"]

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -30,13 +30,13 @@ environment :dev do
   # dev mode.
   set dev_mode: true
   set include_erts: false
-  set cookie: :"LcWJ?&&oKl41r:6VyC.kd`g[[wzlO[DT>2EXPKkQ>quN5XYx$=0}R}?w>jn9_Z!@"
+  set cookie: :""
 end
 
 environment :prod do
   set include_erts: true
   set include_src: false
-  set cookie: :"V0{_Lkp9^K6$}upoGQ=QWk[;kJY:!}G|`q;5}J[th}r_X@]3=/{AW)4O_YjMoFWV"
+  set cookie: :""
 end
 
 # You may define one or more releases in this file.
@@ -52,5 +52,6 @@ release :nerves_hub do
   set applications: [
     :runtime_tools
   ]
+  set vm_args: "rel/vm.args"
 end
 

--- a/rel/scripts/docker-entrypoint.sh
+++ b/rel/scripts/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+$SCRIPT_PATH/s3-sync.sh
+
+exec $@

--- a/rel/scripts/ecs-cluster.sh
+++ b/rel/scripts/ecs-cluster.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+CLUSTER=nerves-hub
+SERVICE=nerves-hub
+
+METADATA=`curl http://169.254.170.2/v2/metadata`
+export LOCAL_IPV4=$(echo $METADATA | jq -r '.Containers[0] .Networks[] .IPv4Addresses[0]')
+export AWS_REGION_NAME=us-east-1
+
+# We need to know what other nodes to hit to bring up the cluster. To do this we
+# need to get a list of all other EC2 private DNS names, because that's how we build the node names
+
+# get all tasks that are running
+TASKS=$(aws ecs list-tasks --cluster $CLUSTER --service-name $SERVICE --output json | jq -r '.taskArns[]')
+IP_ADDRESSES=$(aws ecs describe-tasks --cluster $CLUSTER --tasks $TASKS --output json | jq -r '.tasks[] .containers[] .networkInterfaces[] .privateIpv4Address')
+
+# formatting
+NODES=$(for IP in $IP_ADDRESSES; do echo "'nerves_hub@$IP'"; done)
+NODES=$(echo $NODES | sed -e "s/ /, /g")
+NODE_STRING="[$NODES]"
+
+# we should now have something that looks like
+# ['nerves_hub@10.0.2.120', 'nerves_hub@10.0.3.99']
+export SYNC_NODES_OPTIONAL="$NODE_STRING"
+echo $SYNC_NODES_OPTIONAL
+
+exec nerves_hub foreground

--- a/rel/scripts/s3-sync.sh
+++ b/rel/scripts/s3-sync.sh
@@ -7,5 +7,3 @@ S3_BUCKET=${S3_BUCKET:-'nerves-hub'}
 
 mkdir -p $WORKING_DIR
 aws s3 sync s3://$S3_BUCKET/ssl $WORKING_DIR
-
-exec $@

--- a/rel/vm.args
+++ b/rel/vm.args
@@ -1,0 +1,21 @@
+## Name of the node
+-name nerves_hub@${LOCAL_IPV4}
+
+## Cookie for distributed erlang
+-setcookie "${ERL_COOKIE}"
+
+## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
+## (Disabled by default..use with caution!)
+##-heart
+
+## Enable kernel poll and a few async threads
+##+K true
+##+A 5
+
+## Increase number of concurrent ports/sockets
+##-env ERL_MAX_PORTS 4096
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10
+
+-kernel inet_dist_listen_min 9100 inet_dist_listen_max 9155 sync_nodes_timeout 5000 sync_nodes_optional "${SYNC_NODES_OPTIONAL}" 


### PR DESCRIPTION
We are running at minimum two nodes in production in different availability zones and will need to cluster the group since we are using phoenix channels.