### PR TITLE
Wait for migrations and seeds to complete before upgrading servers.

### DIFF
--- a/rel/scripts/ecs-migrate.sh
+++ b/rel/scripts/ecs-migrate.sh
@@ -5,17 +5,41 @@ set -e
 CLUSTER=$1
 TASK=$2
 
+task_status() {
+  aws ecs describe-tasks --tasks $1 --cluster $CLUSTER | jq -r '.tasks[] .containers[0] .lastStatus'
+}
+
+task_exit_code() {
+  aws ecs describe-tasks --tasks $1 --cluster $CLUSTER | jq -r '.tasks[] .containers[0] .exitCode'
+}
+
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 # Construct the network configuration
 NETWORK_CONFIGURATION=$($SCRIPT_PATH/ecs-network-configuration.sh)
 
 # Run any pending migrations
-aws ecs run-task \
+MIGRATION_TASK=$(aws ecs run-task \
   --cluster $CLUSTER \
   --count 1 \
   --started-by circle-ci \
   --task-definition $TASK \
   --overrides file://rel/scripts/migration-overrides.json \
   --launch-type FARGATE \
-  --network-configuration $NETWORK_CONFIGURATION
+  --network-configuration $NETWORK_CONFIGURATION)
+
+MIGRATION_TASK_ARN=$(echo $MIGRATION_TASK | jq -r '.tasks[0] .taskArn')
+FINISHED=false
+
+until $FINISHED; do
+  STATUS=$(task_status $MIGRATION_TASK_ARN)
+  if [ "$STATUS"  = "STOPPED" ]; then
+    EXIT_CODE=$(task_exit_code $MIGRATION_TASK_ARN)
+    echo "Migration Complete"
+    echo "Exit code: $EXIT_CODE"
+    exit $EXIT_CODE
+  else
+    echo "Migration status $STATUS"
+    sleep 5
+  fi
+done


### PR DESCRIPTION
This will poll aws and wait until the task that was executed to run the migrations returns. This ensures that the data has been migrated prior to updating the application code.