### PR TITLE
Products Table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,6 @@ test: .env
 
 test-watch: .env
 	. ./.env && \
-	    MIX_ENV=dev mix test.watch
+	    MIX_ENV=test mix test.watch
 
 .PHONY: test rebuild-db reset-db mix iex-server server help

--- a/lib/nerves_hub/deployments/deployment.ex
+++ b/lib/nerves_hub/deployments/deployment.ex
@@ -2,18 +2,21 @@ defmodule NervesHub.Deployments.Deployment do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query
 
   alias NervesHub.Accounts.Tenant
   alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Products.Product
+
   alias __MODULE__
 
   @type t :: %__MODULE__{}
-  @required_fields [:tenant_id, :firmware_id, :name, :conditions, :is_active]
+  @required_fields [:product_id, :firmware_id, :name, :conditions, :is_active]
   @optional_fields []
 
   schema "deployments" do
-    belongs_to(:tenant, Tenant)
     belongs_to(:firmware, Firmware)
+    belongs_to(:product, Product)
 
     field(:name, :string)
     field(:conditions, :map)
@@ -40,6 +43,16 @@ defmodule NervesHub.Deployments.Deployment do
     |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_conditions()
+  end
+
+  def with_firmware(deployment_query) do
+    deployment_query
+    |> preload(:firmware)
+  end
+
+  def with_product(deployment_query) do
+    deployment_query
+    |> preload(:product)
   end
 
   defp validate_conditions(changeset, _options \\ []) do

--- a/lib/nerves_hub/deployments/deployments.ex
+++ b/lib/nerves_hub/deployments/deployments.ex
@@ -3,16 +3,18 @@ defmodule NervesHub.Deployments do
 
   alias NervesHub.Deployments.Deployment
   alias NervesHub.Accounts.Tenant
+  alias NervesHub.Products.Product
   alias NervesHub.Repo
   alias Ecto.Changeset
 
-  @spec get_deployments_by_tenant(integer()) :: [Deployment.t()]
-  def get_deployments_by_tenant(tenant_id) do
+  @spec get_deployments_by_product(integer()) :: [Deployment.t()]
+  def get_deployments_by_product(product_id) do
     from(
       d in Deployment,
-      where: d.tenant_id == ^tenant_id,
+      join: p in assoc(d, :product),
+      where: p.id == ^product_id,
       join: f in assoc(d, :firmware),
-      preload: [firmware: f]
+      preload: [firmware: f, product: p]
     )
     |> Repo.all()
   end
@@ -21,9 +23,12 @@ defmodule NervesHub.Deployments do
   def get_deployment(%Tenant{id: tenant_id}, deployment_id) do
     from(
       d in Deployment,
-      where: d.tenant_id == ^tenant_id,
+      join: p in assoc(d, :product),
+      where: p.tenant_id == ^tenant_id,
       where: d.id == ^deployment_id
     )
+    |> Deployment.with_firmware()
+    |> Deployment.with_product()
     |> Repo.one()
     |> case do
       nil ->

--- a/lib/nerves_hub/devices/device.ex
+++ b/lib/nerves_hub/devices/device.ex
@@ -7,6 +7,7 @@ defmodule NervesHub.Devices.Device do
   alias NervesHub.Accounts.Tenant
   alias NervesHub.Deployments.Deployment
   alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Products.Product
 
   alias __MODULE__
 
@@ -16,19 +17,18 @@ defmodule NervesHub.Devices.Device do
     :current_firmware_id,
     :last_communication,
     :description,
-    :product,
     :tags
   ]
-  @required_params [:tenant_id, :identifier, :architecture, :platform]
+  @required_params [:tenant_id, :product_id, :identifier, :architecture, :platform]
 
   schema "devices" do
     belongs_to(:tenant, Tenant)
     belongs_to(:target_deployment, Deployment)
     belongs_to(:current_firmware, Firmware)
+    belongs_to(:product, Product)
 
     field(:identifier, :string)
     field(:description, :string)
-    field(:product, :string)
     field(:platform, :string)
     field(:last_communication, :utc_datetime)
     field(:architecture, :string)

--- a/lib/nerves_hub/devices/devices.ex
+++ b/lib/nerves_hub/devices/devices.ex
@@ -3,11 +3,19 @@ defmodule NervesHub.Devices do
 
   alias NervesHub.Devices.Device
   alias NervesHub.Accounts.Tenant
+  alias NervesHub.Products.Product
   alias NervesHub.Repo
   alias Ecto.Changeset
 
   def get_devices(%Tenant{id: tenant_id}) do
     query = from(d in Device, where: d.tenant_id == ^tenant_id)
+
+    query
+    |> Repo.all()
+  end
+
+  def get_devices(%Product{id: product_id}) do
+    query = from(d in Device, where: d.product_id == ^product_id)
 
     query
     |> Repo.all()

--- a/lib/nerves_hub/firmwares/firmware.ex
+++ b/lib/nerves_hub/firmwares/firmware.ex
@@ -2,9 +2,12 @@ defmodule NervesHub.Firmwares.Firmware do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query
 
   alias NervesHub.Accounts.Tenant
   alias NervesHub.Deployments.Deployment
+  alias NervesHub.Products.Product
+
   alias __MODULE__
 
   @type t :: %__MODULE__{}
@@ -12,7 +15,6 @@ defmodule NervesHub.Firmwares.Firmware do
     :author,
     :description,
     :misc,
-    :product,
     :tenant_key_id,
     :vcs_identifier
   ]
@@ -20,6 +22,7 @@ defmodule NervesHub.Firmwares.Firmware do
     :architecture,
     :platform,
     :tenant_id,
+    :product_id,
     :uuid,
     :upload_metadata,
     :version
@@ -27,6 +30,7 @@ defmodule NervesHub.Firmwares.Firmware do
 
   schema "firmwares" do
     belongs_to(:tenant, Tenant)
+    belongs_to(:product, Product)
     has_many(:deployment, Deployment)
 
     field(:architecture, :string)
@@ -34,7 +38,6 @@ defmodule NervesHub.Firmwares.Firmware do
     field(:description, :string)
     field(:misc, :string)
     field(:platform, :string)
-    field(:product, :string)
     field(:tenant_key_id, :integer)
     field(:upload_metadata, :map)
     field(:uuid, :string)
@@ -48,6 +51,11 @@ defmodule NervesHub.Firmwares.Firmware do
     firmware
     |> cast(params, @required_params ++ @optional_params)
     |> validate_required(@required_params)
+  end
+
+  def with_product(firmware_query) do
+    firmware_query
+    |> preload(:product)
   end
 
   @spec fetch_metadata_item(String.t(), String.t()) :: {:ok, String.t()} | {:error, :not_found}

--- a/lib/nerves_hub/products/product.ex
+++ b/lib/nerves_hub/products/product.ex
@@ -1,0 +1,31 @@
+defmodule NervesHub.Products.Product do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias NervesHub.Accounts.Tenant
+  alias NervesHub.Firmwares.Firmware
+  alias NervesHub.Devices.Device
+  alias NervesHub.Deployments.Deployment
+
+  @required_params [:name, :tenant_id]
+  @optional_params []
+
+  schema "products" do
+    has_many(:devices, Device)
+    has_many(:deployments, Deployment)
+    has_many(:firmwares, Firmware)
+
+    belongs_to(:tenant, Tenant)
+
+    field(:name, :string)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(product, attrs) do
+    product
+    |> cast(attrs, @required_params ++ @optional_params)
+    |> validate_required(@required_params)
+  end
+end

--- a/lib/nerves_hub/products/products.ex
+++ b/lib/nerves_hub/products/products.ex
@@ -1,0 +1,123 @@
+defmodule NervesHub.Products do
+  @moduledoc """
+  The Products context.
+  """
+
+  import Ecto.Query, warn: false
+  alias NervesHub.Repo
+
+  alias NervesHub.Products.Product
+  alias NervesHub.Accounts.Tenant
+
+  @doc """
+  Returns the list of products.
+
+  ## Examples
+
+      iex> list_products()
+      [%Product{}, ...]
+
+  """
+  def list_products do
+    Repo.all(Product)
+  end
+
+  @doc """
+  Gets a single product.
+
+  Raises `Ecto.NoResultsError` if the Product does not exist.
+
+  ## Examples
+
+      iex> get_product!(123)
+      %Product{}
+
+      iex> get_product!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_product!(id), do: Repo.get!(Product, id)
+
+  def get_product_with_tenant(%Tenant{} = tenant, id) do
+    Product
+    |> Repo.get_by(id: id, tenant_id: tenant.id)
+    |> case do
+      nil -> {:error, :not_found}
+      product -> {:ok, product}
+    end
+  end
+
+  def get_product_by_tenant_id_and_name(tenant_id, name) do
+    Product
+    |> Repo.get_by(tenant_id: tenant_id, name: name)
+    |> case do
+      nil -> {:error, :not_found}
+      product -> {:ok, product}
+    end
+  end
+
+  @doc """
+  Creates a product.
+
+  ## Examples
+
+      iex> create_product(%{field: value})
+      {:ok, %Product{}}
+
+      iex> create_product(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_product(attrs \\ %{}) do
+    %Product{}
+    |> Product.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a product.
+
+  ## Examples
+
+      iex> update_product(product, %{field: new_value})
+      {:ok, %Product{}}
+
+      iex> update_product(product, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_product(%Product{} = product, attrs) do
+    product
+    |> Product.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Product.
+
+  ## Examples
+
+      iex> delete_product(product)
+      {:ok, %Product{}}
+
+      iex> delete_product(product)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_product(%Product{} = product) do
+    Repo.delete(product)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking product changes.
+
+  ## Examples
+
+      iex> change_product(product)
+      %Ecto.Changeset{source: %Product{}}
+
+  """
+  def change_product(%Product{} = product) do
+    Product.changeset(product, %{})
+  end
+end

--- a/lib/nerves_hub_web/controllers/product_controller.ex
+++ b/lib/nerves_hub_web/controllers/product_controller.ex
@@ -1,0 +1,62 @@
+defmodule NervesHubWeb.ProductController do
+  use NervesHubWeb, :controller
+
+  alias NervesHub.Products
+  alias NervesHub.Products.Product
+
+  def index(conn, _params) do
+    products = Products.list_products()
+    render(conn, "index.html", products: products)
+  end
+
+  def new(conn, _params) do
+    changeset = Products.change_product(%Product{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(%{assigns: %{tenant: tenant}} = conn, %{"product" => product_params}) do
+    case Products.create_product(product_params |> Enum.into(%{"tenant_id" => tenant.id})) do
+      {:ok, product} ->
+        conn
+        |> put_flash(:info, "Product created successfully.")
+        |> redirect(to: product_path(conn, :show, product))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    product = Products.get_product!(id)
+    render(conn, "show.html", product: product)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    product = Products.get_product!(id)
+    changeset = Products.change_product(product)
+    render(conn, "edit.html", product: product, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "product" => product_params}) do
+    product = Products.get_product!(id)
+
+    case Products.update_product(product, product_params) do
+      {:ok, product} ->
+        conn
+        |> put_flash(:info, "Product updated successfully.")
+        |> redirect(to: product_path(conn, :show, product))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", product: product, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    product = Products.get_product!(id)
+    {:ok, _product} = Products.delete_product(product)
+
+    conn
+    |> put_flash(:info, "Product deleted successfully.")
+    |> redirect(to: product_path(conn, :index))
+  end
+end

--- a/lib/nerves_hub_web/plugs/fetch_device.ex
+++ b/lib/nerves_hub_web/plugs/fetch_device.ex
@@ -7,7 +7,10 @@ defmodule NervesHubWeb.Plugs.FetchDevice do
     opts
   end
 
-  def call(%{assigns: %{tenant: tenant}, params: %{"device_id" => device_id}} = conn, _opts) do
+  def call(
+        %{assigns: %{tenant: tenant}, params: %{"device" => %{"id" => device_id}}} = conn,
+        _opts
+      ) do
     tenant
     |> Devices.get_device(device_id)
     |> case do

--- a/lib/nerves_hub_web/plugs/fetch_product.ex
+++ b/lib/nerves_hub_web/plugs/fetch_product.ex
@@ -1,0 +1,18 @@
+defmodule NervesHubWeb.Plugs.FetchProduct do
+  import Plug.Conn
+
+  alias NervesHub.Products
+
+  def init(opts) do
+    opts
+  end
+
+  def call(%{params: %{"product_id" => product_id}} = conn, _opts) do
+    with {:ok, product} <- Products.get_product_with_tenant(conn.assigns.tenant, product_id) do
+      conn
+      |> assign(:product, product)
+    else
+      _ -> conn
+    end
+  end
+end

--- a/lib/nerves_hub_web/plugs/fetch_tenant.ex
+++ b/lib/nerves_hub_web/plugs/fetch_tenant.ex
@@ -7,6 +7,13 @@ defmodule NervesHubWeb.Plugs.FetchTenant do
     opts
   end
 
+  def call(%{params: %{"tenant_id" => tenant_id}} = conn, _opts) do
+    tenant = Accounts.get_tenant(tenant_id)
+
+    conn
+    |> assign(:tenant, tenant)
+  end
+
   def call(%{assigns: %{user: user}} = conn, _opts) do
     user.tenant_id
     |> Accounts.get_tenant()

--- a/lib/nerves_hub_web/templates/dashboard/index.html.eex
+++ b/lib/nerves_hub_web/templates/dashboard/index.html.eex
@@ -2,8 +2,8 @@
   <h1 class="display-4 text-left">Welcome, <%= @conn.assigns.user.name %>!</h1>
   <p class="lead text-left">NervesHub helps you manage firmware updates for Nerves devices.</p>
   <hr class="my-4">
-  <p class="text-left">To get started, add a device by clicking the button below.</p>
+  <p class="text-left">To get started, add a product by clicking the button below.</p>
   <p class="text-left">
-    <a class="btn btn-primary btn-lg" href="<%= device_path(@conn, :new) %>" role="button">Add a Device</a>
+    <a class="btn btn-primary btn-lg" href="<%= product_path(@conn, :new) %>" role="button">Add a Product</a>
   </p>
 </div>

--- a/lib/nerves_hub_web/templates/deployment/edit.html.eex
+++ b/lib/nerves_hub_web/templates/deployment/edit.html.eex
@@ -1,13 +1,13 @@
 <h1>Edit deployment</h1>
 
-<%= form_for @changeset, deployment_path(@conn, :update, @deployment), [as: :deployment], fn f -> %>
+<%= form_for @changeset, product_deployment_path(@conn, :update, @product.id, @deployment), [as: :deployment], fn f -> %>
   <h3 class="h3">Firmware Details</h3>
 
   <table class="table" style="width: auto">
     <tbody>
       <tr>
         <th>Product</th>
-        <td><%= @firmware.product %></td>
+        <td><%= @product.name %></td>
       </tr>
       <tr>
         <th>Version</th>

--- a/lib/nerves_hub_web/templates/deployment/index.html.eex
+++ b/lib/nerves_hub_web/templates/deployment/index.html.eex
@@ -1,7 +1,7 @@
 <h1>
   Deployments
 
-  <a class="btn btn-lg btn-primary pull-right" href="<%= deployment_path(@conn, :new) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= product_deployment_path(@conn, :new, @product.id) %>">
     Create Deployment
   </a>
 </h1>
@@ -26,7 +26,7 @@
           <%= if deployment.is_active, do: "Active", else: "Inactive" %>
         </span>
       </td>
-      <td><a class="btn btn-secondary" href="<%= deployment_path(@conn, :show, deployment.id) %>">Details</a></td>
+      <td><a class="btn btn-secondary" href="<%= product_deployment_path(@conn, :show, @product.id, deployment.id) %>">Details</a></td>
     </tr>
   <% end %>
 </table>

--- a/lib/nerves_hub_web/templates/deployment/new.html.eex
+++ b/lib/nerves_hub_web/templates/deployment/new.html.eex
@@ -1,13 +1,13 @@
 <h1>Create Deployment</h1>
 
-<%= form_for @changeset, deployment_path(@conn, :create), [as: :deployment], fn f -> %>
+<%= form_for @changeset, product_deployment_path(@conn, :create, @product.id), [as: :deployment], fn f -> %>
   <h3 class="h3">Firmware Details</h3>
 
   <table class="table" style="width: auto">
     <tbody>
       <tr>
-        <th>Product</th>
-        <td><%= @firmware.product %>
+        <th>Product Name</th>
+        <td><%= @firmware.product.name %>
       </tr>
       <tr>
         <th>Version</th>

--- a/lib/nerves_hub_web/templates/deployment/select-firmware.html.eex
+++ b/lib/nerves_hub_web/templates/deployment/select-firmware.html.eex
@@ -1,6 +1,6 @@
 <h1>Select Firmware for New Deployment</h1>
 
-<%= form_for @conn, deployment_path(@conn, :new), [method: :get, as: :deployment], fn f -> %>
+<%= form_for @conn, product_deployment_path(@conn, :new, @product.id), [method: :get, as: :deployment], fn f -> %>
   <div class="form-group">
     <label for="firmware_id">Firmware</label>
     <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>

--- a/lib/nerves_hub_web/templates/deployment/show.html.eex
+++ b/lib/nerves_hub_web/templates/deployment/show.html.eex
@@ -29,15 +29,15 @@
   </tbody>
 </table>
 
-<a class="btn btn-primary" href="<%= deployment_path(@conn, :edit, @deployment) %>">
+<a class="btn btn-primary" href="<%= product_deployment_path(@conn, :edit, @product.id, @deployment) %>">
   Edit Deployment
 </a>
 
-<%= form_for @conn, deployment_path(@conn, :update, @deployment), [as: :deployment, method: "put"], fn f -> %>
-  <%= hidden_input f, :is_active, id: "is_active_input", value: !@deployment.is_active %>  
+<%= form_for @conn, product_deployment_path(@conn, :update, @product.id, @deployment), [as: :deployment, method: "put"], fn f -> %>
+  <%= hidden_input f, :is_active, id: "is_active_input", value: !@deployment.is_active %>
   <%= submit "Make #{opposite_status(@deployment)}", class: "btn btn-primary" %>
 <% end %>
 
-<%= form_for @conn, deployment_path(@conn, :delete, @deployment), [method: :delete], fn _ -> %>
+<%= form_for @conn, product_deployment_path(@conn, :delete, @product.id, @deployment), [method: :delete], fn _ -> %>
   <%= submit "Delete Deployment", class: "btn btn-danger", onclick: "return confirm('Are you sure you want to delete this deployment? This can not be undone.')" %>
 <% end %>

--- a/lib/nerves_hub_web/templates/device/edit.html.eex
+++ b/lib/nerves_hub_web/templates/device/edit.html.eex
@@ -17,7 +17,7 @@
   </tr>
 </table>
 
-<%= form_for @changeset, device_path(@conn, :update, @device.id), fn f -> %>
+<%= form_for @changeset, product_device_path(@conn, :update, @product.id, @device.id), fn f -> %>
   <div class="form-group">
     <label for="tags">Tags</label>
     <%= text_input f, :tags, class: "form-control", id: "tags" %>
@@ -26,7 +26,7 @@
 
   <%= submit "Update Tags", class: "btn btn-primary" %>
 
-  <a class="btn btn-secondary" href="<%= device_path(@conn, :index) %>">
+  <a class="btn btn-secondary" href="<%= product_device_path(@conn, :index, @product.id) %>">
     Cancel
   </a>
 <% end %>

--- a/lib/nerves_hub_web/templates/device/index.html.eex
+++ b/lib/nerves_hub_web/templates/device/index.html.eex
@@ -1,9 +1,5 @@
 <h1>
   Devices
-
-  <a class="btn btn-lg btn-primary pull-right" href="<%= device_path(@conn, :new) %>">
-    Add Device
-  </a>
 </h1>
 
 <table class="table table-striped">
@@ -33,7 +29,7 @@
           <% end %>
         </td>
         <td>
-          <a href="<%= device_path(@conn, :edit, device.id) %>" class="btn btn-info">Edit</a>
+          <a href="<%= product_device_path(@conn, :edit, device.product_id, device.id) %>" class="btn btn-info">Edit</a>
           <a href="#" class="btn btn-danger">Delete</a>
           <a href="#" class="btn btn-warning">Disable</a>
         </td>

--- a/lib/nerves_hub_web/templates/device/new.html.eex
+++ b/lib/nerves_hub_web/templates/device/new.html.eex
@@ -2,7 +2,7 @@
   <h1>Create a Device</h1>
 </div>
 
-<%= form_for @changeset, device_path(@conn, :create), fn f -> %>
+<%= form_for @changeset, product_device_path(@conn, :create, @product.id), fn f -> %>
   <div class="form-group">
     <label for="identifier">Identifier</label>
     <%= text_input f, :identifier, class: "form-control", id: "identifier" %>

--- a/lib/nerves_hub_web/templates/device/show.html.eex
+++ b/lib/nerves_hub_web/templates/device/show.html.eex
@@ -1,0 +1,12 @@
+<h2>Show Device</h2>
+
+<ul>
+
+  <li>
+    <strong>Identifier:</strong>
+    <%= @device.identifier %>
+  </li>
+
+</ul>
+
+<span><%= link "Back", to: product_device_path(@conn, :index, @product.id) %></span>

--- a/lib/nerves_hub_web/templates/firmware/index.html.eex
+++ b/lib/nerves_hub_web/templates/firmware/index.html.eex
@@ -1,7 +1,7 @@
 <h1>
   Firmware
 
-  <a class="btn btn-lg btn-primary pull-right" href="<%= firmware_path(@conn, :upload) %>">
+  <a class="btn btn-lg btn-primary pull-right" href="<%= product_firmware_path(@conn, :upload, @product.id) %>">
     Upload Firmware
   </a>
 </h1>
@@ -24,7 +24,7 @@
   </thead>
   <%= for firmware <- @firmwares do %>
     <tr>
-      <td><%= firmware.product %></td>
+      <td><%= firmware.product.name %></td>
       <td><%= firmware.version %></td>
       <td><%= firmware.platform %></td>
       <td><%= firmware.architecture %></td>
@@ -34,7 +34,7 @@
       <td><%= firmware.author %></td>
       <td><%= format_signed(firmware, @tenant) %></td>
       <td><pre class="pre-scrollable"><%= firmware.misc %></pre></td>
-      <td><%= link("Download", to: firmware_path(@conn, :download, firmware.id)) %></td>
+      <td><%= link("Download", to: product_firmware_path(@conn, :download, @product.id, firmware.id)) %></td>
     </tr>
   <% end %>
 </table>

--- a/lib/nerves_hub_web/templates/firmware/upload.html.eex
+++ b/lib/nerves_hub_web/templates/firmware/upload.html.eex
@@ -1,4 +1,4 @@
-<%= form_for @changeset, firmware_path(@conn, :do_upload), [multipart: true], fn f -> %>
+<%= form_for @changeset, product_firmware_path(@conn, :do_upload, @product.id), [multipart: true], fn f -> %>
   <div class="form-group">
     <label for="file_input">Select File</label>
     <%= file_input f, :file, required: true, id: "file_input" %>

--- a/lib/nerves_hub_web/templates/product/edit.html.eex
+++ b/lib/nerves_hub_web/templates/product/edit.html.eex
@@ -1,0 +1,5 @@
+<h2>Edit Product</h2>
+
+<%= render "form.html", Map.put(assigns, :action, product_path(@conn, :update, @product)) %>
+
+<span><%= link "Back", to: product_path(@conn, :index) %></span>

--- a/lib/nerves_hub_web/templates/product/form.html.eex
+++ b/lib/nerves_hub_web/templates/product/form.html.eex
@@ -1,0 +1,15 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :name %>
+  <%= text_input f, :name %>
+  <%= error_tag f, :name %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+<% end %>

--- a/lib/nerves_hub_web/templates/product/index.html.eex
+++ b/lib/nerves_hub_web/templates/product/index.html.eex
@@ -1,0 +1,26 @@
+<h2>Listing Products</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for product <- @products do %>
+    <tr>
+      <td><%= product.name %></td>
+
+      <td>
+        <%= link "Show", to: product_path(@conn, :show, product) %>
+        <%= link "Edit", to: product_path(@conn, :edit, product) %>
+        <%= link "Delete", to: product_path(@conn, :delete, product), method: :delete, data: [confirm: "Are you sure?"] %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Product", to: product_path(@conn, :new) %></span>

--- a/lib/nerves_hub_web/templates/product/new.html.eex
+++ b/lib/nerves_hub_web/templates/product/new.html.eex
@@ -1,0 +1,5 @@
+<h2>New Product</h2>
+
+<%= render "form.html", Map.put(assigns, :action, product_path(@conn, :create)) %>
+
+<span><%= link "Back", to: product_path(@conn, :index) %></span>

--- a/lib/nerves_hub_web/templates/product/show.html.eex
+++ b/lib/nerves_hub_web/templates/product/show.html.eex
@@ -1,0 +1,19 @@
+<h2>Show Product
+  <a class="btn btn-lg btn-primary pull-right" href="<%= product_device_path(@conn, :new, @product.id) %>">
+    Add Device
+  </a>
+</h2>
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @product.name %>
+  </li>
+
+  <a class="btn btn-lg btn-primary pull-right" href="<%= product_device_path(@conn, :index, @product.id) %>">
+ View Devices
+  </a>
+</ul>
+
+<span><%= link "Edit", to: product_path(@conn, :edit, @product) %></span>
+<span><%= link "Back", to: product_path(@conn, :index) %></span>

--- a/lib/nerves_hub_web/views/deployment_view.ex
+++ b/lib/nerves_hub_web/views/deployment_view.ex
@@ -11,8 +11,8 @@ defmodule NervesHubWeb.DeploymentView do
 
   def firmware_display_name(%Firmware{} = f) do
     case f.version do
-      nil -> f.product
-      version -> "#{version} (#{f.product})"
+      nil -> f.version
+      version -> "#{version} (#{f.version})"
     end
   end
 

--- a/lib/nerves_hub_web/views/layout_view.ex
+++ b/lib/nerves_hub_web/views/layout_view.ex
@@ -5,10 +5,9 @@ defmodule NervesHubWeb.LayoutView do
 
   def navigation_links(conn) do
     [
-      {"Devices", device_path(conn, :index)},
-      {"Firmware", firmware_path(conn, :index)},
-      {"Deployments", deployment_path(conn, :index)},
-      {"Tenant", tenant_path(conn, :edit)},
+      {conn.assigns.tenant.name, tenant_path(conn, :edit)},
+      {"Products", product_path(conn, :index)},
+      {"All Devices", device_path(conn, :index)},
       {"Account", account_path(conn, :edit)}
     ]
   end

--- a/lib/nerves_hub_web/views/product_view.ex
+++ b/lib/nerves_hub_web/views/product_view.ex
@@ -1,0 +1,3 @@
+defmodule NervesHubWeb.ProductView do
+  use NervesHubWeb, :view
+end

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule NervesHub.MixProject do
       {:phoenix_swoosh, "~> 0.2"},
       {:nerves_hub_client, github: "nerves-hub/nerves_hub_client", only: :test},
       {:excoveralls, "~> 0.8", only: :test},
-      {:mix_test_watch, "~> 0.6", only: :dev, runtime: false},
+      {:mix_test_watch, "~> 0.6", only: :test, runtime: false},
       {:ex_aws, "~> 2.0"},
       {:ex_aws_s3, "~> 2.0"},
       {:hackney, "~> 1.9"},

--- a/priv/repo/migrations/20180618171943_device_deployment_id.exs
+++ b/priv/repo/migrations/20180618171943_device_deployment_id.exs
@@ -12,10 +12,12 @@ defmodule NervesHub.Repo.Migrations.DeviceDeploymentId do
   end
 
   def down do
-    add(:target_version, :string, null: true)
-    add(:current_version, :string, null: true)
+    alter table(:devices) do
+      add(:target_version, :string, null: true)
+      add(:current_version, :string, null: true)
 
-    remove(:target_deployment_id)
-    remove(:current_firmware_id)
+      remove(:target_deployment_id)
+      remove(:current_firmware_id)
+    end
   end
 end

--- a/priv/repo/migrations/20180710140434_create_products.exs
+++ b/priv/repo/migrations/20180710140434_create_products.exs
@@ -1,0 +1,50 @@
+defmodule NervesHub.Repo.Migrations.CreateProducts do
+  use Ecto.Migration
+
+  def up do
+    create table(:products) do
+      add(:name, :string)
+      add(:tenant_id, references(:tenants, null: false))
+
+      timestamps()
+    end
+
+    alter table(:devices) do
+      add(:product_id, references(:products, null: false))
+      remove(:product)
+    end
+
+    alter table(:firmwares) do
+      add(:product_id, references(:products, null: false))
+      remove(:product)
+    end
+
+    alter table(:deployments) do
+      add(:product_id, references(:products, null: false))
+      remove(:tenant_id)
+    end
+
+    create(index(:products, [:tenant_id]))
+    unique_index(:products, [:tenant_id, :name], name: :products_tenant_id_name_index)
+    unique_index(:deployments, [:product_id, :name], name: :deployments_product_id_name_index)
+  end
+
+  def down do
+    drop(table(:products))
+
+    alter table(:devices) do
+      remove(:product_id)
+      add(:product, :string)
+    end
+
+    alter table(:firmwares) do
+      remove(:product_id)
+      add(:product, :string)
+    end
+
+    alter table(:deployments) do
+      remove(:product_id)
+      add(:tenant_id, references(:tenants, null: false))
+    end
+  end
+end

--- a/test/nerves_hub/deployments/deployments_test.exs
+++ b/test/nerves_hub/deployments/deployments_test.exs
@@ -7,17 +7,21 @@ defmodule NervesHub.DeploymentsTest do
 
   setup do
     tenant = Fixtures.tenant_fixture()
+    product = Fixtures.product_fixture(tenant)
     tenant_key = Fixtures.tenant_key_fixture(tenant)
-    firmware = Fixtures.firmware_fixture(tenant, tenant_key)
-    deployment = Fixtures.deployment_fixture(tenant, firmware)
+    firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
+    deployment = Fixtures.deployment_fixture(tenant, firmware, product)
 
-    {:ok, %{tenant: tenant, firmware: firmware, deployment: deployment}}
+    {:ok, %{tenant: tenant, firmware: firmware, deployment: deployment, product: product}}
   end
 
-  test 'create_deployment with valid parameters', %{tenant: tenant, firmware: firmware} do
+  test 'create_deployment with valid parameters', %{
+    firmware: firmware,
+    product: product
+  } do
     params = %{
-      tenant_id: tenant.id,
       firmware_id: firmware.id,
+      product_id: product.id,
       name: "my deployment",
       conditions: %{
         "version" => "< 1.0.0",

--- a/test/nerves_hub/devices/devices_test.exs
+++ b/test/nerves_hub/devices/devices_test.exs
@@ -7,17 +7,30 @@ defmodule NervesHub.DevicesTest do
 
   setup do
     tenant = Fixtures.tenant_fixture()
+    product = Fixtures.product_fixture(tenant)
     tenant_key = Fixtures.tenant_key_fixture(tenant)
-    firmware = Fixtures.firmware_fixture(tenant, tenant_key)
-    deployment = Fixtures.deployment_fixture(tenant, firmware)
-    device = Fixtures.device_fixture(tenant, firmware, deployment)
+    firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
+    deployment = Fixtures.deployment_fixture(tenant, firmware, product)
+    device = Fixtures.device_fixture(tenant, firmware, deployment, product)
 
-    {:ok, %{tenant: tenant, firmware: firmware, deployment: deployment, device: device}}
+    {:ok,
+     %{
+       tenant: tenant,
+       firmware: firmware,
+       device: device,
+       deployment: deployment,
+       product: product
+     }}
   end
 
-  test 'create_device with valid parameters', %{tenant: tenant, firmware: firmware} do
+  test 'create_device with valid parameters', %{
+    tenant: tenant,
+    firmware: firmware,
+    product: product
+  } do
     params = %{
       tenant_id: tenant.id,
+      product_id: product.id,
       identifier: "valid identifier",
       architecture: firmware.architecture,
       platform: firmware.platform

--- a/test/nerves_hub/integration/websocket_test.exs
+++ b/test/nerves_hub/integration/websocket_test.exs
@@ -45,18 +45,18 @@ defmodule NervesHub.Integration.WebsocketTest do
 
   def device_fixture(device_params \\ %{}, firmware_uuid \\ "foo") do
     tenant = Fixtures.tenant_fixture()
+    product = Fixtures.product_fixture(tenant)
     tenant_key = Fixtures.tenant_key_fixture(tenant)
 
     firmware =
-      Fixtures.firmware_fixture(tenant, tenant_key, %{
-        product: @valid_product,
+      Fixtures.firmware_fixture(tenant, tenant_key, product, %{
         uuid: firmware_uuid,
         version: "0.0.1",
         upload_metadata: %{"public_path" => @valid_firmware_url}
       })
 
-    deployment = Fixtures.deployment_fixture(tenant, firmware)
-    Fixtures.device_fixture(tenant, firmware, deployment, device_params)
+    deployment = Fixtures.deployment_fixture(tenant, firmware, product)
+    Fixtures.device_fixture(tenant, firmware, deployment, product, device_params)
   end
 
   defmodule ClientSocket do
@@ -219,9 +219,10 @@ defmodule NervesHub.Integration.WebsocketTest do
         |> device_fixture("not_foobar")
 
       tenant = %Accounts.Tenant{id: device.tenant_id}
+      product = Fixtures.product_fixture(tenant)
       tenant_key = Fixtures.tenant_key_fixture(tenant, %{name: "another key"})
 
-      Fixtures.firmware_fixture(tenant, tenant_key, %{
+      Fixtures.firmware_fixture(tenant, tenant_key, product, %{
         uuid: query_uuid
       })
 

--- a/test/nerves_hub/products/products_test.exs
+++ b/test/nerves_hub/products/products_test.exs
@@ -1,0 +1,62 @@
+defmodule NervesHub.ProductsTest do
+  use NervesHub.DataCase
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Products
+
+  describe "products" do
+    alias NervesHub.Products.Product
+
+    @valid_attrs %{name: "some name"}
+    @update_attrs %{name: "some updated name"}
+    @invalid_attrs %{name: nil}
+
+    setup do
+      tenant = Fixtures.tenant_fixture()
+      product = Fixtures.product_fixture(tenant, @valid_attrs)
+
+      {:ok, %{product: product, tenant: tenant}}
+    end
+
+    test "list_products/0 returns all products", %{product: product} do
+      assert Products.list_products() == [product]
+    end
+
+    test "get_product!/1 returns the product with given id", %{product: product} do
+      assert Products.get_product!(product.id) == product
+    end
+
+    test "create_product/1 with valid data creates a product", %{tenant: tenant} do
+      assert {:ok, %Product{} = product} =
+               %{tenant_id: tenant.id}
+               |> Enum.into(@valid_attrs)
+               |> Products.create_product()
+
+      assert product.name == "some name"
+    end
+
+    test "create_product/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Products.create_product(@invalid_attrs)
+    end
+
+    test "update_product/2 with valid data updates the product", %{product: product} do
+      assert {:ok, %Product{} = product} = Products.update_product(product, @update_attrs)
+
+      assert product.name == "some updated name"
+    end
+
+    test "update_product/2 with invalid data returns error changeset", %{product: product} do
+      assert {:error, %Ecto.Changeset{}} = Products.update_product(product, @invalid_attrs)
+      assert product == Products.get_product!(product.id)
+    end
+
+    test "delete_product/1 deletes the product", %{product: product} do
+      assert {:ok, %Product{}} = Products.delete_product(product)
+      assert_raise Ecto.NoResultsError, fn -> Products.get_product!(product.id) end
+    end
+
+    test "change_product/1 returns a product changeset", %{product: product} do
+      assert %Ecto.Changeset{} = Products.change_product(product)
+    end
+  end
+end

--- a/test/nerves_hub_web/controllers/deployment_controller_test.exs
+++ b/test/nerves_hub_web/controllers/deployment_controller_test.exs
@@ -5,8 +5,10 @@ defmodule NervesHubWeb.DeploymentControllerTest do
   alias NervesHub.Deployments
 
   describe "index" do
-    test "lists all deployments", %{conn: conn} do
-      conn = get(conn, deployment_path(conn, :index))
+    test "lists all deployments", %{conn: conn, current_tenant: tenant} do
+      product = Fixtures.product_fixture(tenant)
+
+      conn = get(conn, product_deployment_path(conn, :index, product.id))
       assert html_response(conn, 200) =~ "Deployments"
     end
   end
@@ -17,22 +19,56 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       current_tenant: tenant,
       tenant_key: tenant_key
     } do
-      firmware = Fixtures.firmware_fixture(tenant, tenant_key)
-      conn = get(conn, deployment_path(conn, :new), deployment: %{firmware_id: firmware.id})
+      product = Fixtures.product_fixture(tenant)
+      firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
+
+      conn =
+        get(
+          conn,
+          product_deployment_path(conn, :new, product.id),
+          deployment: %{firmware_id: firmware.id}
+        )
 
       assert html_response(conn, 200) =~ "Create Deployment"
+
+      assert html_response(conn, 200) =~ product_deployment_path(conn, :create, product.id)
     end
 
-    test "redirects with invalid firmware", %{conn: conn} do
-      conn = get(conn, deployment_path(conn, :new), deployment: %{firmware_id: -1})
+    test "redirects with invalid firmware", %{conn: conn, current_tenant: tenant} do
+      product = Fixtures.product_fixture(tenant)
 
-      assert redirected_to(conn, 302) =~ deployment_path(conn, :new)
+      conn =
+        get(conn, product_deployment_path(conn, :new, product.id), deployment: %{firmware_id: -1})
+
+      assert redirected_to(conn, 302) =~ product_deployment_path(conn, :new, product.id)
     end
 
-    test "redirects form with no firmware", %{conn: conn} do
-      conn = get(conn, deployment_path(conn, :new))
+    test "renders select firmware when no firmware_id is passed", %{
+      conn: conn,
+      current_tenant: tenant,
+      tenant_key: tenant_key
+    } do
+      product = Fixtures.product_fixture(tenant)
+      Fixtures.firmware_fixture(tenant, tenant_key, product)
+      conn = get(conn, product_deployment_path(conn, :new, product.id))
 
-      assert redirected_to(conn, 302) =~ firmware_path(conn, :index)
+      assert html_response(conn, 200) =~ "Select Firmware for New Deployment"
+      assert html_response(conn, 200) =~ product_deployment_path(conn, :create, product.id)
+    end
+
+    test "redirects to firmware upload firmware_id is passed and no firmwares are found" do
+      tenant = Fixtures.tenant_fixture(%{name: "empty tenant"})
+      user = Fixtures.user_fixture(tenant, %{email: "new@tenant.com"})
+      product = Fixtures.product_fixture(tenant)
+
+      conn =
+        build_conn()
+        |> Map.put(:assigns, %{tenant: tenant})
+        |> init_test_session(%{"auth_user_id" => user.id})
+
+      conn = get(conn, product_deployment_path(conn, :new, product.id))
+
+      assert redirected_to(conn, 302) =~ product_firmware_path(conn, :upload, product.id)
     end
   end
 
@@ -42,7 +78,12 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       current_tenant: tenant,
       tenant_key: tenant_key
     } do
-      firmware = Fixtures.firmware_fixture(tenant, tenant_key)
+      product = Fixtures.product_fixture(tenant)
+
+      firmware =
+        Fixtures.firmware_fixture(tenant, tenant_key, product, %{
+          version: "relatively unusual version"
+        })
 
       deployment_params = %{
         firmware_id: firmware.id,
@@ -54,13 +95,21 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       }
 
       # check that we end up in the right place
-      create_conn = post(conn, deployment_path(conn, :create), deployment: deployment_params)
-      assert redirected_to(create_conn, 302) =~ deployment_path(conn, :index)
+      create_conn =
+        post(
+          conn,
+          product_deployment_path(conn, :create, product.id),
+          deployment: deployment_params
+        )
+
+      assert redirected_to(create_conn, 302) =~
+               product_deployment_path(create_conn, :index, product.id)
 
       # check that the proper creation side effects took place
-      conn = get(conn, deployment_path(conn, :index))
+      conn = get(conn, product_deployment_path(conn, :index, product.id))
       assert html_response(conn, 200) =~ deployment_params.name
       assert html_response(conn, 200) =~ "Inactive"
+      assert html_response(conn, 200) =~ firmware.version
     end
   end
 
@@ -70,11 +119,15 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       current_tenant: tenant,
       tenant_key: tenant_key
     } do
-      firmware = Fixtures.firmware_fixture(tenant, tenant_key)
-      deployment = Fixtures.deployment_fixture(tenant, firmware)
+      product = Fixtures.product_fixture(tenant)
+      firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
+      deployment = Fixtures.deployment_fixture(tenant, firmware, product)
 
-      conn = get(conn, deployment_path(conn, :edit, deployment))
+      conn = get(conn, product_deployment_path(conn, :edit, product.id, deployment))
       assert html_response(conn, 200) =~ "Edit"
+
+      assert html_response(conn, 200) =~
+               product_deployment_path(conn, :update, product.id, deployment)
     end
   end
 
@@ -84,13 +137,14 @@ defmodule NervesHubWeb.DeploymentControllerTest do
       current_tenant: tenant,
       tenant_key: tenant_key
     } do
-      firmware = Fixtures.firmware_fixture(tenant, tenant_key)
-      deployment = Fixtures.deployment_fixture(tenant, firmware)
+      product = Fixtures.product_fixture(tenant)
+      firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
+      deployment = Fixtures.deployment_fixture(tenant, firmware, product)
 
       conn =
         put(
           conn,
-          deployment_path(conn, :update, deployment),
+          product_deployment_path(conn, :update, product.id, deployment),
           deployment: %{
             "version" => "4.3.2",
             "tags" => "new, tags, now",
@@ -101,7 +155,9 @@ defmodule NervesHubWeb.DeploymentControllerTest do
 
       {:ok, reloaded_deployment} = Deployments.get_deployment(tenant, deployment.id)
 
-      assert redirected_to(conn, 302) =~ deployment_path(conn, :show, deployment)
+      assert redirected_to(conn, 302) =~
+               product_deployment_path(conn, :show, product.id, deployment)
+
       assert reloaded_deployment.name == "not original"
       assert reloaded_deployment.conditions["version"] == "4.3.2"
       assert Enum.sort(reloaded_deployment.conditions["tags"]) == Enum.sort(~w(new tags now))
@@ -110,11 +166,12 @@ defmodule NervesHubWeb.DeploymentControllerTest do
 
   describe "delete deployment" do
     test "deletes chosen resource", %{conn: conn, current_tenant: tenant, tenant_key: tenant_key} do
-      firmware = Fixtures.firmware_fixture(tenant, tenant_key)
-      deployment = Fixtures.deployment_fixture(tenant, firmware)
+      product = Fixtures.product_fixture(tenant)
+      firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
+      deployment = Fixtures.deployment_fixture(tenant, firmware, product)
 
-      conn = delete(conn, deployment_path(conn, :delete, deployment))
-      assert redirected_to(conn) == deployment_path(conn, :index)
+      conn = delete(conn, product_deployment_path(conn, :delete, product.id, deployment))
+      assert redirected_to(conn) == product_deployment_path(conn, :index, product.id)
       assert Deployments.get_deployment(tenant, deployment.id) == {:error, :not_found}
     end
   end

--- a/test/nerves_hub_web/controllers/device_controller_test.exs
+++ b/test/nerves_hub_web/controllers/device_controller_test.exs
@@ -2,19 +2,36 @@ defmodule NervesHubWeb.DeviceControllerTest do
   use NervesHubWeb.ConnCase.Browser
 
   alias NervesHub.Fixtures
+  alias NervesHub.Devices
 
   describe "index" do
     test "lists all devices", %{conn: conn} do
       conn = get(conn, device_path(conn, :index))
       assert html_response(conn, 200) =~ "Devices"
     end
+
+    test "does not list devices for other tenants", %{conn: conn} do
+      %{device: device} = Fixtures.smartrent_fixture()
+      conn = get(conn, device_path(conn, :index))
+      refute html_response(conn, 200) =~ device.identifier
+    end
   end
 
   describe "new device" do
     test "renders form with valid request params", %{conn: conn} do
-      conn = get(conn, device_path(conn, :new))
+      product = Fixtures.product_fixture(conn)
+      new_conn = get(conn, product_device_path(conn, :new, product.id))
 
-      assert html_response(conn, 200) =~ "Create a Device"
+      assert html_response(new_conn, 200) =~ "Create a Device"
+      assert html_response(new_conn, 200) =~ "products/#{product.id}/devices"
+    end
+
+    test "does not render form with product id from wrong tenant", %{conn: conn} do
+      %{product: product} = Fixtures.smartrent_fixture()
+
+      new_conn = get(conn, product_device_path(conn, :new, product.id))
+
+      assert redirected_to(new_conn, 302) =~ dashboard_path(new_conn, :index)
     end
   end
 
@@ -24,11 +41,10 @@ defmodule NervesHubWeb.DeviceControllerTest do
       current_tenant: tenant,
       tenant_key: tenant_key
     } do
-      firmware = Fixtures.firmware_fixture(tenant, tenant_key)
+      product = Fixtures.product_fixture(conn)
+      firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
 
       device_params = %{
-        # firmware_id: firmware.id,
-        # tenant_id: tenant.id,
         architecture: firmware.architecture,
         platform: firmware.platform,
         identifier: "device_identifier",
@@ -36,12 +52,98 @@ defmodule NervesHubWeb.DeviceControllerTest do
       }
 
       # check that we end up in the right place
-      create_conn = post(conn, device_path(conn, :create), device: device_params)
+      create_conn =
+        post(conn, product_device_path(conn, :create, product.id), device: device_params)
+
       assert redirected_to(create_conn, 302) =~ device_path(conn, :index)
 
       # check that the proper creation side effects took place
       conn = get(conn, device_path(conn, :index))
       assert html_response(conn, 200) =~ device_params.identifier
+    end
+
+    test "cannot create device with product id from wrong tenant", %{
+      conn: conn,
+      current_tenant: tenant,
+      tenant_key: tenant_key
+    } do
+      product = Fixtures.product_fixture(conn)
+      firmware = Fixtures.firmware_fixture(tenant, tenant_key, product)
+
+      %{product: wrong_product} = Fixtures.smartrent_fixture()
+
+      device_params = %{
+        architecture: firmware.architecture,
+        platform: firmware.platform,
+        identifier: "device_identifier",
+        tags: "beta, beta-edge"
+      }
+
+      create_conn =
+        post(conn, product_device_path(conn, :create, wrong_product.id), device: device_params)
+
+      assert redirected_to(create_conn, 302) =~ dashboard_path(create_conn, :index)
+    end
+  end
+
+  describe "edit device" do
+    test "renders edit page", %{
+      conn: conn,
+      current_tenant: tenant
+    } do
+      [to_edit | _] = Devices.get_devices(tenant)
+      conn = get(conn, product_device_path(conn, :edit, to_edit.product_id, to_edit))
+
+      assert html_response(conn, 200) =~ "Device Details"
+    end
+  end
+
+  describe "update device" do
+    test "with valid params", %{
+      conn: conn,
+      current_tenant: tenant
+    } do
+      [to_update | _] = Devices.get_devices(tenant)
+
+      device_params = %{
+        identifier: "new_identifier",
+        tags: "beta, beta-edge"
+      }
+
+      update_conn =
+        put(
+          conn,
+          product_device_path(conn, :update, to_update.product_id, to_update.id),
+          device: device_params
+        )
+
+      assert redirected_to(update_conn) ==
+               product_device_path(conn, :show, to_update.product_id, to_update.id)
+
+      show_conn = get(conn, product_device_path(conn, :show, to_update.product_id, to_update.id))
+      assert html_response(show_conn, 200) =~ "new_identifier"
+    end
+
+    test "cannot update with product id from wrong tenant", %{
+      conn: conn,
+      current_tenant: tenant
+    } do
+      [to_update | _] = Devices.get_devices(tenant)
+      %{product: wrong_product} = Fixtures.smartrent_fixture()
+
+      device_params = %{
+        identifier: "device_identifier",
+        tags: "beta, beta-edge"
+      }
+
+      update_conn =
+        put(
+          conn,
+          product_device_path(conn, :update, wrong_product.id, to_update.id),
+          device: device_params
+        )
+
+      assert redirected_to(update_conn, 302) =~ dashboard_path(update_conn, :index)
     end
   end
 end

--- a/test/nerves_hub_web/controllers/firmware_controller_test.exs
+++ b/test/nerves_hub_web/controllers/firmware_controller_test.exs
@@ -1,59 +1,85 @@
 defmodule NervesHubWeb.FirmwareControllerTest do
   use NervesHubWeb.ConnCase.Browser
 
+  alias NervesHub.Fixtures
+
   describe "index" do
-    test "lists all firmwares", %{conn: conn} do
-      conn = get(conn, firmware_path(conn, :index))
+    test "lists all firmwares", %{conn: conn, current_tenant: tenant} do
+      product = Fixtures.product_fixture(tenant)
+
+      conn = get(conn, product_firmware_path(conn, :index, product.id))
       assert html_response(conn, 200) =~ "Firmware"
+      assert html_response(conn, 200) =~ product_firmware_path(conn, :upload, product.id)
     end
   end
 
   describe "upload firmware form" do
-    test "renders form with valid request params", %{conn: conn} do
-      conn = get(conn, firmware_path(conn, :upload))
+    test "renders form with valid request params", %{conn: conn, current_tenant: tenant} do
+      product = Fixtures.product_fixture(tenant)
+      conn = get(conn, product_firmware_path(conn, :upload, product.id))
 
       assert html_response(conn, 200) =~ "Upload Firmware"
+      assert html_response(conn, 200) =~ product_firmware_path(conn, :do_upload, product.id)
     end
   end
 
   describe "upload firmware" do
-    test "redirects after successful upload", %{conn: conn} do
+    test "redirects after successful upload", %{
+      conn: conn,
+      current_tenant: tenant
+    } do
+      product = Fixtures.product_fixture(tenant, %{name: "starter"})
+
       upload = %Plug.Upload{
         path: "test/fixtures/firmware/signed-key1.fw",
         filename: "signed-key1.fw"
       }
 
       # check that we end up in the right place
-      create_conn = post(conn, "/firmware/upload", %{"firmware" => %{"file" => upload}})
-      assert redirected_to(create_conn, 302) =~ firmware_path(conn, :index)
+      create_conn =
+        post(conn, product_firmware_path(conn, :upload, product.id), %{
+          "firmware" => %{"file" => upload}
+        })
+
+      assert redirected_to(create_conn, 302) =~ product_firmware_path(conn, :index, product.id)
 
       # check that the proper creation side effects took place
-      conn = get(conn, firmware_path(conn, :index))
+      conn = get(conn, product_firmware_path(conn, :index, product.id))
       # starter is the product for the test firmware
       assert html_response(conn, 200) =~ "starter"
     end
 
-    test "error if corrupt firmware uploaded", %{conn: conn} do
+    test "error if corrupt firmware uploaded", %{conn: conn, current_tenant: tenant} do
+      product = Fixtures.product_fixture(tenant, %{name: "starter"})
+
       upload = %Plug.Upload{
         path: "test/fixtures/firmware/corrupt.fw",
         filename: "corrupt.fw"
       }
 
       # check for the error message
-      conn = post(conn, "/firmware/upload", %{"firmware" => %{"file" => upload}})
+      conn =
+        post(conn, product_firmware_path(conn, :upload, product.id), %{
+          "firmware" => %{"file" => upload}
+        })
 
       assert html_response(conn, 200) =~
                "Firmware corrupt, signature invalid or missing public key"
     end
 
-    test "error if tenant keys do not match firmware", %{conn: conn} do
+    test "error if tenant keys do not match firmware", %{conn: conn, current_tenant: tenant} do
+      product = Fixtures.product_fixture(tenant, %{name: "starter"})
+
       upload = %Plug.Upload{
         path: "test/fixtures/firmware/signed-other-key.fw",
         filename: "signed-other-key.fw"
       }
 
       # check for the error message
-      conn = post(conn, "/firmware/upload", %{"firmware" => %{"file" => upload}})
+      conn =
+        post(conn, product_firmware_path(conn, :upload, product.id), %{
+          "firmware" => %{"file" => upload}
+        })
 
       assert html_response(conn, 200) =~
                "Firmware corrupt, signature invalid or missing public key"

--- a/test/nerves_hub_web/controllers/product_controller_test.exs
+++ b/test/nerves_hub_web/controllers/product_controller_test.exs
@@ -1,0 +1,94 @@
+defmodule NervesHubWeb.ProductControllerTest do
+  use NervesHubWeb.ConnCase.Browser
+
+  alias NervesHub.Fixtures
+  alias NervesHub.Products
+
+  @create_attrs %{name: "some name"}
+  @update_attrs %{name: "some updated name"}
+  @invalid_attrs %{name: nil}
+
+  def fixture(:product) do
+    {:ok, product} = Products.create_product(@create_attrs)
+    product
+  end
+
+  describe "index" do
+    test "lists all products", %{conn: conn} do
+      conn = get(conn, product_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Products"
+    end
+  end
+
+  describe "new product" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, product_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Product"
+    end
+  end
+
+  describe "create product" do
+    test "redirects to show when data is valid", %{conn: conn, current_tenant: tenant} do
+      conn = post(conn, product_path(conn, :create), product: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == product_path(conn, :show, id)
+
+      conn = get(conn, product_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Product"
+      assert html_response(conn, 200) =~ tenant.name
+      assert html_response(conn, 200) =~ product_device_path(conn, :new, id)
+      assert html_response(conn, 200) =~ product_device_path(conn, :index, id)
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, product_path(conn, :create), product: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Product"
+    end
+  end
+
+  describe "edit product" do
+    setup [:create_product]
+
+    test "renders form for editing chosen product", %{conn: conn, product: product} do
+      conn = get(conn, product_path(conn, :edit, product))
+      assert html_response(conn, 200) =~ "Edit Product"
+    end
+  end
+
+  describe "update product" do
+    setup [:create_product]
+
+    test "redirects when data is valid", %{conn: conn, product: product} do
+      conn = put(conn, product_path(conn, :update, product), product: @update_attrs)
+      assert redirected_to(conn) == product_path(conn, :show, product)
+
+      conn = get(conn, product_path(conn, :show, product))
+      assert html_response(conn, 200) =~ "some updated name"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, product: product} do
+      conn = put(conn, product_path(conn, :update, product), product: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Product"
+    end
+  end
+
+  describe "delete product" do
+    setup [:create_product]
+
+    test "deletes chosen product", %{conn: conn, product: product} do
+      conn = delete(conn, product_path(conn, :delete, product))
+      assert redirected_to(conn) == product_path(conn, :index)
+
+      assert_error_sent(404, fn ->
+        get(conn, product_path(conn, :show, product))
+      end)
+    end
+  end
+
+  defp create_product(_) do
+    tenant = Fixtures.tenant_fixture()
+    product = Fixtures.product_fixture(tenant)
+    {:ok, product: product, tenant: tenant}
+  end
+end

--- a/test/support/browser_case.ex
+++ b/test/support/browser_case.ex
@@ -10,7 +10,14 @@ defmodule NervesHubWeb.ConnCase.Browser do
       import Plug.Test
 
       setup do
-        {:ok, tenant} = NervesHub.Accounts.create_tenant(%{name: "Browser Tenant"})
+        %{
+          tenant: tenant,
+          tenant_key: tenant_key,
+          user: user,
+          firmware: firmware,
+          deployment: deployment,
+          product: product
+        } = NervesHub.Fixtures.very_fixture()
 
         {:ok, tenant_key} =
           NervesHub.Accounts.create_tenant_key(%{
@@ -19,20 +26,12 @@ defmodule NervesHubWeb.ConnCase.Browser do
             key: File.read!("test/fixtures/firmware/fwup-key1.pub")
           })
 
-        {:ok, default_user} =
-          tenant
-          |> NervesHub.Accounts.create_user(%{
-            name: "Browser User",
-            email: "user@browser.com",
-            password: "password"
-          })
-
         conn =
           build_conn()
           |> Map.put(:assigns, %{tenant: tenant})
-          |> init_test_session(%{"auth_user_id" => default_user.id})
+          |> init_test_session(%{"auth_user_id" => user.id})
 
-        %{conn: conn, current_user: default_user, current_tenant: tenant, tenant_key: tenant_key}
+        %{conn: conn, current_user: user, current_tenant: tenant, tenant_key: tenant_key}
       end
     end
   end


### PR DESCRIPTION
## Why:
* It is good to have a database schema that matches the structure of the
real world use cases.
* The `:product` string fields make it difficult to properly identify devices for deployments.

## This change addresses the need by:
* Products table (per the ERD)
* Scoping `devices`, `firmwares`, and `deployments` to a `product`.

## Questions this has brought up for me:
* There is no `delete` function in the device controller, is this intentional?
* Is there any reason the patterns established by the the phoenix generators weren't used on our existing controllers?
* I noticed plugs in the controller, but I typically have used them in the router with `pipe_through`.  This seems more clear to me, but I'm open to being told why it is wrong.

## Author's Note:
This got a bit out of hand when my changes broke all of the controllers.
I tried to implement my view of how this should work, but I may have
missed some things, and others may not like things I did (like scoping
various entities to a product).