### PR TITLE
Fix paths to seeds.exs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ rebuild-db:
 	mix ecto.drop && \
 	mix ecto.create && \
 	mix ecto.migrate && \
-	mix run priv/repo/seeds.exs
+	mix run apps/nerves_hub_core/priv/repo/seeds.exs
 
 test: .env
 	. ./.env && \

--- a/apps/nerves_hub/mix.exs
+++ b/apps/nerves_hub/mix.exs
@@ -70,7 +70,7 @@ defmodule NervesHub.MixProject do
       {:sweet_xml, "~> 0.6"},
       {:distillery, "~> 1.5"},
       {:nerves_hub_core, in_umbrella: true},
-      {:nerves_hub_device, in_umbrella: true},
+      {:nerves_hub_device, in_umbrella: true}
     ]
   end
 
@@ -82,7 +82,7 @@ defmodule NervesHub.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run ../nerves_hub_core/priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,11 @@ defmodule NervesHubUmbrella.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": [
+        "ecto.create",
+        "ecto.migrate",
+        "run apps/nerves_hub_core/priv/repo/seeds.exs"
+      ],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]


### PR DESCRIPTION
Why:

* It got overlooked in the switch to the umbrella.
* `make reset-db` was broken for me, so I figured it was a matter of
time for others.

This change addresses the need by:

* fixing the path of `seeds.ex`