### PR TITLE
Let user's know if their firmware changeset was invalid

### DIFF
--- a/apps/nerves_hub/lib/nerves_hub_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub/lib/nerves_hub_web/controllers/firmware_controller.ex
@@ -53,8 +53,17 @@ defmodule NervesHubWeb.FirmwareController do
           |> put_flash(:info, "Firmware uploaded")
           |> redirect(to: product_firmware_path(conn, :index, product.id))
 
+        {:error,
+         %Ecto.Changeset{
+           errors: [product_id: {"can't be blank", [validation: :required]}]
+         } = changeset} ->
+          conn
+          |> put_flash(:error, "No matching product could be found.")
+          |> render("upload.html", changeset: changeset)
+
         {:error, changeset} ->
           conn
+          |> put_flash(:error, "Unknown error uploading firmware.")
           |> render("upload.html", changeset: changeset)
       end
     else

--- a/apps/nerves_hub/test/nerves_hub_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub/test/nerves_hub_web/controllers/firmware_controller_test.exs
@@ -84,5 +84,25 @@ defmodule NervesHubWeb.FirmwareControllerTest do
       assert html_response(conn, 200) =~
                "Firmware corrupt, signature invalid or missing public key"
     end
+
+    test "error if meta-product does not match product name", %{
+      conn: conn,
+      current_tenant: tenant
+    } do
+      product = Fixtures.product_fixture(tenant, %{name: "non-matching name"})
+
+      upload = %Plug.Upload{
+        path: "../../test/fixtures/firmware/signed-key1.fw",
+        filename: "signed-key1.fw"
+      }
+
+      # check for the error message
+      conn =
+        post(conn, product_firmware_path(conn, :upload, product.id), %{
+          "firmware" => %{"file" => upload}
+        })
+
+      assert html_response(conn, 200) =~ "No matching product could be found."
+    end
   end
 end


### PR DESCRIPTION
Why:

* We want users to know why their firmware didn't make the cut
* Addresses: https://github.com/nerves-hub/nerves_hub/issues/109

This change addresses the need by:

* Checking for an error in the changeset and flashing that error.