### PR TITLE
Configure distinct db in test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,14 @@ rebuild-db:
 
 test: .env
 	. ./.env && \
-	    MIX_ENV=test mix test
+	DATABASE_URL=postgres://db:db@localhost:2345/nerves_hub_test \
+	MIX_ENV=test \
+	mix test
 
 test-watch: .env
 	. ./.env && \
-	    MIX_ENV=test mix test.watch
+	DATABASE_URL=postgres://db:db@localhost:2345/nerves_hub_test \
+	MIX_ENV=test \
+	mix test.watch
 
 .PHONY: test rebuild-db reset-db mix iex-server server help

--- a/apps/nerves_hub_core/config/dev.exs
+++ b/apps/nerves_hub_core/config/dev.exs
@@ -2,5 +2,4 @@ use Mix.Config
 
 config :nerves_hub_core, NervesHubCore.Repo,
   adapter: Ecto.Adapters.Postgres,
-  url: System.get_env("DATABASE_URL"),
   ssl: false

--- a/apps/nerves_hub_core/config/prod.exs
+++ b/apps/nerves_hub_core/config/prod.exs
@@ -2,4 +2,3 @@ use Mix.Config
 
 config :nerves_hub_core, NervesHubCore.Repo,
   adapter: Ecto.Adapters.Postgres,
-  url: "${DATABASE_URL}"

--- a/apps/nerves_hub_core/config/test.exs
+++ b/apps/nerves_hub_core/config/test.exs
@@ -2,7 +2,5 @@ use Mix.Config
 
 config :nerves_hub_core, NervesHubCore.Repo,
   adapter: Ecto.Adapters.Postgres,
-  url: System.get_env("DATABASE_URL"),
   ssl: false,
-  database: "nerves_hub_test",
   pool: Ecto.Adapters.SQL.Sandbox


### PR DESCRIPTION
Why
---

* Previously dev and test were sharing the `db` database causing tests
to fail surprisingly

How
---

* Set test-specific `DATABASE_URL` env var in Makefile when running
tests
* Remove vestigial (even prior to this commit) `url: ...` and
`database: ...` mix repo configurations

PR
--

This addresses the issue of dev records being propagated "into" test and causing
tests to fail. There were a few misleading things at play here.

* Test config was configuring both `:url` and `:database`, potentially
implying some sort of merged functionality, or that the `:database` was taking
precedence. This is not the case, when `:url` is specified no other config is
aknowledged
* `:url` and friends like `:database` in mix configs were having no impact on
reality because `NervesHubCore.Repo` pulls in `DATABASE_URL` from the env at
runtime in its init callback overriding the `:url` option. This is what caused
dev and test to create and connect to the same database

This could be solved many different ways but I think using an env var across the
board provides consistency. In lieu of maintaining a `test.env` I opted to
override `DATABASE_URL` for test in the Makefile like we do for `MIX_ENV`.