### PR TITLE
Remove core prod ecto url config

### DIFF
--- a/apps/nerves_hub_core/config/prod.exs
+++ b/apps/nerves_hub_core/config/prod.exs
@@ -1,5 +1,4 @@
 use Mix.Config
 
 config :nerves_hub_core, NervesHubCore.Repo,
-  adapter: Ecto.Adapters.Postgres,
-  url: "${DATABASE_URL}"
+  adapter: Ecto.Adapters.Postgres


### PR DESCRIPTION
This config has no effect since the `NervesHubCore.Repo` module's init
callback reads from runtime and overrides `:url` anyway.