### PR TITLE
Add firmware link to product page

### DIFF
--- a/apps/nerves_hub/lib/nerves_hub_web/templates/product/show.html.eex
+++ b/apps/nerves_hub/lib/nerves_hub_web/templates/product/show.html.eex
@@ -10,6 +10,9 @@
     <%= @product.name %>
   </li>
 
+  <a class="btn btn-lg btn-primary pull-right" href="<%= product_firmware_path(@conn, :index, @product.id) %>">
+ View Firmware
+  </a>
   <a class="btn btn-lg btn-primary pull-right" href="<%= product_device_path(@conn, :index, @product.id) %>">
  View Devices
   </a>

--- a/apps/nerves_hub/test/nerves_hub_web/controllers/product_controller_test.exs
+++ b/apps/nerves_hub/test/nerves_hub_web/controllers/product_controller_test.exs
@@ -39,6 +39,7 @@ defmodule NervesHubWeb.ProductControllerTest do
       assert html_response(conn, 200) =~ tenant.name
       assert html_response(conn, 200) =~ product_device_path(conn, :new, id)
       assert html_response(conn, 200) =~ product_device_path(conn, :index, id)
+      assert html_response(conn, 200) =~ product_firmware_path(conn, :index, id)
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
Why:

* We didn't have one

This change addresses the need by:

* Adding the link.
* Testing for its presence.

Caveats:
* It needs styling, but we're going to wait until we get a good idea of
what the product page layout should look like.