### PR TITLE
Show the readme contents by default

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule NervesHub.MixProject do
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      docs: [extras: ["README.md"]],
+      docs: [main: "readme", extras: ["README.md"]],
       description: description(),
       package: package()
     ]


### PR DESCRIPTION
The readme looks more useful for people learning about nerves_hub, so
make it show up by default in the docs.