### PR TITLE
Abstract Nerves.Runtime to allow easier local work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 nerves_hub-*.tar
 
+nerves-hub

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,17 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :nerves_hub, NervesHub.Socket,
-  url: "wss://127.0.0.1:4001/socket/websocket",
-  serializer: Jason,
-  ssl_verify: :verify_peer,
-  socket_opts: [
-    certfile: Path.expand("../test/fixtures/certs/hub-1234.pem") |> to_charlist,
-    keyfile: Path.expand("../test/fixtures/certs/hub-1234-key.pem") |> to_charlist,
-    cacertfile: Path.expand("../test/fixtures/certs/ca.pem") |> to_charlist,
-    server_name_indication: 'device.nerves-hub.org'
-  ]
-
 config :logger, level: :info
 
 # Import environment specific config. This must remain at the bottom

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,11 +1,47 @@
 use Mix.Config
 
-config :nerves_hub, NervesHub.API,
+## Local NervesHub config.
+
+# Configure the CLI to use a local instance.
+config :nerves_hub_cli, NervesHubCLI.API,
   host: "0.0.0.0",
-  port: 4002,
-  ssl: [
-    keyfile: Path.expand("../test/fixtures/ssl/user-key.pem", __DIR__),
-    certfile: Path.expand("../test/fixtures/ssl/user.pem", __DIR__),
-    cacertfile: Path.expand("../test/fixtures/ssl/ca.pem", __DIR__),
-    server_name_indication: 'api.nerves-hub.org'
-  ]
+  port: 4002
+
+# Configure the CLI to use local fixtures.
+config :nerves_hub_cli,
+  home: Path.expand("../nerves-hub", __DIR__),
+  ca_certs: Path.expand("../test/fixtures/ca_certs", __DIR__)
+
+# Configure the socket to use a local instance.
+config :nerves_hub, NervesHub.Socket, url: "wss://0.0.0.0:4001/socket/websocket"
+
+# Configure NervesHub to use the TestIdentifier.
+config :nerves_hub,
+  ca_certs: Path.expand("../test/fixtures/ca_certs", __DIR__),
+  identifier: NervesHub.TestIdentifier
+
+test_uuid = "test"
+
+# A chicken and egg problem here.
+# We can only use the keys if they exist.
+# This requires developers to do
+#   mix nerves_hub device create
+# before compileing this application to generate certs.
+
+cert =
+  case File.read(Path.expand("../nerves-hub/#{test_uuid}-cert.pem", __DIR__)) do
+    {:ok, pem} -> pem
+    _ -> nil
+  end
+
+key =
+  case File.read(Path.expand("../nerves-hub/#{test_uuid}-key.pem", __DIR__)) do
+    {:ok, pem} -> pem
+    _ -> nil
+  end
+
+config :nerves_hub, NervesHub.TestIdentifier,
+  # We only want to set the uuid if a cert and key exist.
+  uuid: cert && key && test_uuid,
+  cert: cert,
+  key: key

--- a/lib/nerves_hub/firmware_channel.ex
+++ b/lib/nerves_hub/firmware_channel.ex
@@ -2,10 +2,10 @@ defmodule NervesHub.FirmwareChannel do
   use PhoenixChannelClient
   require Logger
 
-  alias NervesHub.HTTPClient
+  alias NervesHub.{HTTPClient, Identifier}
 
   def topic do
-    "firmware:" <> Nerves.Runtime.KV.get_active("nerves_fw_uuid")
+    "firmware:" <> Identifier.get_uuid()
   end
 
   def handle_in("update", params, state) do

--- a/lib/nerves_hub/identifier.ex
+++ b/lib/nerves_hub/identifier.ex
@@ -1,0 +1,34 @@
+defmodule NervesHub.Identifier do
+  @moduledoc """
+  Behaviour for identifying a device.
+  """
+  @default_identifier NervesHub.NervesRuntimeIdentifier
+
+  @type uuid() :: binary()
+
+  @type cert() :: binary()
+
+  @type key() :: binary()
+
+  @doc "Should return a binary firmware UUID"
+  @callback get_uuid() :: uuid()
+
+  @doc "Should return a text cert"
+  @callback get_cert() :: cert()
+
+  @doc "Shoudl return a text key"
+  @callback get_key() :: key()
+
+  @doc "Returns the uuid of the current device"
+  def get_uuid(), do: identifier().get_uuid()
+
+  @doc "Returns the ssl cert of the current device"
+  def get_cert(), do: identifier().get_cert()
+
+  @doc "Returns the key of the current device"
+  def get_key(), do: identifier().get_key()
+
+  defp identifier() do
+    Application.get_env(:nerves_hub, :identifier, @default_identifier)
+  end
+end

--- a/lib/nerves_hub/nerves_runtime_identifier.ex
+++ b/lib/nerves_hub/nerves_runtime_identifier.ex
@@ -1,0 +1,16 @@
+defmodule NervesHub.NervesRuntimeIdentifier do
+  @doc "The default NervesHub Identifier"
+  @behaviour NervesHub.Identifier
+
+  @cert "nerves_hub_cert"
+  @key "nerves_hub_key"
+
+  @impl NervesHub.Identifier
+  def get_uuid(), do: Nerves.Runtime.KV.get_active("nerves_fw_uuid")
+
+  @impl NervesHub.Identifier
+  def get_cert(), do: Nerves.Runtime.KV.get(@cert)
+
+  @impl NervesHub.Identifier
+  def get_key(), do: Nerves.Runtime.KV.get(@key)
+end

--- a/lib/nerves_hub/socket.ex
+++ b/lib/nerves_hub/socket.ex
@@ -1,10 +1,8 @@
 defmodule NervesHub.Socket do
   use PhoenixChannelClient.Socket, otp_app: :nerves_hub
 
-  alias NervesHub.Certificate
+  alias NervesHub.{Certificate, Identifier}
 
-  @cert "nerves_hub_cert"
-  @key "nerves_hub_key"
   @server_name "device.nerves-hub.org"
   @url "wss://" <> @server_name <> "/socket/websocket"
 
@@ -12,8 +10,8 @@ defmodule NervesHub.Socket do
 
   def configure(user_config) when is_list(user_config) do
     ca_certs = Certificate.ca_certs()
-    cert = Nerves.Runtime.KV.get(@cert) |> Certificate.pem_to_der()
-    key = Nerves.Runtime.KV.get(@key) |> Certificate.pem_to_der()
+    cert = Identifier.get_cert() |> Certificate.pem_to_der()
+    key = Identifier.get_key() |> Certificate.pem_to_der()
 
     server_name =
       (user_config[:server_name_indication] || @server_name)

--- a/lib/nerves_hub/test_identifier.ex
+++ b/lib/nerves_hub/test_identifier.ex
@@ -1,0 +1,25 @@
+defmodule NervesHub.TestIdentifier do
+  @moduledoc "Host/Test identifier."
+  @behaviour NervesHub.Identifier
+  @error """
+  Test Identifier was not configured correctly. Configure it in
+  your config.exs file:
+
+  config :nerves_hub, NervesHub.TestIdentifier,
+    uuid: "some uuid",
+    cert: "binary cert file",
+    key: "binary key file"
+  """
+
+  @impl NervesHub.Identifier
+  def get_uuid(),
+    do: Application.get_env(:nerves_hub, __MODULE__, [])[:uuid] || raise(@error)
+
+  @impl NervesHub.Identifier
+  def get_cert(),
+    do: Application.get_env(:nerves_hub, __MODULE__, [])[:cert] || raise(@error)
+
+  @impl NervesHub.Identifier
+  def get_key(),
+    do: Application.get_env(:nerves_hub, __MODULE__, [])[:key] || raise(@error)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule NervesHub.MixProject do
       {:phoenix_channel_client, "~> 0.3"},
       {:websocket_client, "~> 1.3"},
       {:jason, "~> 1.0"},
-      {:nerves_runtime, ">= 0.6.5"},
+      {:nerves_runtime, ">= 0.6.5", app: Mix.env() == :prod},
       {:nerves_hub_cli, "~> 0.1", runtime: false},
       {:ex_doc, "~> 0.18", only: [:dev, :test], runtime: false}
     ]


### PR DESCRIPTION
Cleaned up `config.exs` entries. This will allow tests to be ran
and makes testing any channel features not require a real device.