### PR TITLE
Doc updates through firmware key creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ and simply use the product name `example`.
 Create a new product on NervesHub by running:
 
 ```bash
-mix nerves_hub.product create --name example
+mix nerves_hub.product create
 ```
 
 ### Creating NervesHub firmware signing keys


### PR DESCRIPTION
The updates stop right before publishing except for some consistency changes since I changed the name of the firmware signing key from `test` to `devkey`.