### PR TITLE
Configure nerves_runtime with the MIX_TARGET to fix running on host

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,9 @@ config :nerves_hub, NervesHub.Socket,
     server_name_indication: 'device.nerves-hub.org'
   ]
 
+config :nerves_runtime,
+  target: System.get_env("MIX_TARGET") || "host"
+
 config :logger, level: :info
 
 # Import environment specific config. This must remain at the bottom

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "nerves_hub_cli": {:hex, :nerves_hub_cli, "0.4.0", "d5efcc49179fff8f3cd4542831820082d6abf2290fb5251c85e54ea51614b35d", [:mix], [{:hackney, "~> 1.9", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:pbcs, "~> 0.1", [hex: :pbcs, repo: "hexpm", optional: false]}, {:tesla, "~> 1.2.1 or ~> 1.3", [hex: :tesla, repo: "hexpm", optional: false]}, {:x509, "~> 0.3", [hex: :x509, repo: "hexpm", optional: false]}], "hexpm"},
-  "nerves_runtime": {:hex, :nerves_runtime, "0.6.5", "7b43e555be567252b60fd927efe295881e79328fc19b03a1b69dbe4fbf78249f", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:system_registry, "~> 0.5", [hex: :system_registry, repo: "hexpm", optional: false]}], "hexpm"},
+  "nerves_runtime": {:hex, :nerves_runtime, "0.8.0", "9657810438a346122a15762deafc4a7adda4aeb545c57681b5aed0fb0f635617", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}, {:system_registry, "~> 0.5", [hex: :system_registry, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "pbcs": {:hex, :pbcs, "0.1.0", "6f79ce81d93edf5ac41fcd8b32fb203ad6895ebdb33d115e14a5bd955b90020a", [:mix], [], "hexpm"},


### PR DESCRIPTION
Official `MIX_TARGET` support is on the roadmap for Elixir 1.8. Until then, we need to pass this information forward to `nerves_runtime`. This will allow `nerves_hub` to be run on the host.

https://github.com/elixir-lang/elixir/issues/8063