### PR TITLE
Fix issue with resolving keys for orgs defined in the mix project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ nerves_hub-*.tar
 
 /.nerves-hub
 /nerves-hub
+/test/tmp

--- a/lib/nerves_hub/certificate.ex
+++ b/lib/nerves_hub/certificate.ex
@@ -1,7 +1,4 @@
 defmodule NervesHub.Certificate do
-  @public_keys Application.get_env(:nerves_hub, :public_keys, [])
-               |> NervesHubCLI.public_keys()
-
   def pem_to_der(<<"-----BEGIN", _rest::binary>> = cert) do
     [{_, cert, _}] = :public_key.pem_decode(cert)
     cert
@@ -24,9 +21,5 @@ defmodule NervesHub.Certificate do
     |> File.ls!()
     |> Enum.map(&File.read!(Path.join(ca_cert_path, &1)))
     |> Enum.map(&pem_to_der/1)
-  end
-
-  def public_keys do
-    @public_keys
   end
 end

--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -23,7 +23,7 @@ defmodule NervesHub.HTTPFwupStream do
     args = ["--apply", "--no-unmount", "-d", devpath, "--task", "upgrade"]
 
     args =
-      Enum.reduce(NervesHub.Certificate.public_keys(), args, fn public_key, args ->
+      Enum.reduce(NervesHub.public_keys(), args, fn public_key, args ->
         args ++ ["--public-key", public_key]
       end)
 

--- a/test/nerves_hub_test.exs
+++ b/test/nerves_hub_test.exs
@@ -1,4 +1,16 @@
 defmodule NervesHubTest do
   use ExUnit.Case
   doctest NervesHub
+
+  test "encode / decode keys" do
+    keys = ["abcd", "efgh", "ijkl"]
+
+    tmp_dir = Path.expand("test/tmp")
+    File.mkdir_p(tmp_dir)
+
+    key_file = Path.join(tmp_dir, "keys")
+    File.write!(key_file, Enum.join(keys, "\n"), [:write])
+
+    assert keys == NervesHub.public_keys(key_file)
+  end
 end


### PR DESCRIPTION
If you create a project and define the org in the Mix.Project.config(), the public keys from the config.exs will reference the default org instead of the one defined in the project config. This is due to where the compiler is in the project stack at he time it is trying to expand the key atoms from the key store. This updates the project requirements to add the `:nerves_hub` compiler to the project's compilers. This moves the time of execution to when the main project's config is in scope on the stack which lets nerves_hub make the right org choice.

Here is an example on how this is added:

```elixir
  def project do
    [
      app: :my_app,
      version: "0.1.0",
      # ...
      compilers: [:nerves_hub] ++ Mix.compilers(),
      # ...
    ]
  end
```