### PR TITLE
Update CA certs to be pulled from the correct app

### DIFF
--- a/lib/nerves_hub/certificate.ex
+++ b/lib/nerves_hub/certificate.ex
@@ -3,8 +3,8 @@ defmodule NervesHub.Certificate do
                |> NervesHubCLI.public_keys()
 
   ca_cert_path =
-    Application.get_env(:nerves_hub_core, :ca_certs) || System.get_env("NERVES_HUB_CA_CERTS") ||
-      :code.priv_dir(:nerves_hub_core)
+    Application.get_env(:nerves_hub, :ca_certs) || System.get_env("NERVES_HUB_CA_CERTS") ||
+      :code.priv_dir(:nerves_hub)
       |> to_string()
       |> Path.join("ca_certs")
 


### PR DESCRIPTION
I don't know if this is the correct solution. If we want to still  use `nerves_hub_core`, the certs in that application are wrong. 

Fixes #44