### PR TITLE
Add more text and a check for firmware signing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,14 +197,34 @@ mix nerves_hub.key create devkey
 ```
 
 On success, you'll see the public key. You can confirm using the NervesHub web
-interface that the signing key exists.
+interface that the public key exists. Private keys are never sent to the
+NervesHub server. NervesHub requires valid signatures from known keys on all
+firmware it distributes.
 
-Next, add the key's name to your `config.exs` so that it can be built into your
-firmware image:
+The next step is to make sure that the public key is embedded into the firmware
+image. This is important. The device uses this key to verify the firmware it
+receives from a NervesHub server before applying the update.  This protects the
+device against anyone tampering with the firmware image between when it was
+signed by you and when it is installed.
+
+All firmware signing public keys need to be added to your `config.exs`. Keys
+that are stored locally (like the one we just created) can be referred to by
+their atom name:
 
 ```elixir
 config :nerves_hub,
   public_keys: [:devkey]
+```
+
+If you have keys that cannot be stored locally, you will have to copy/paste
+their public key:
+
+```elixir
+config :nerves_hub,
+  public_keys: [
+    # devkey
+    "bM/O9+ykZhCWx8uZVgx0sU3f0JJX7mqnAVU9VGeuHr4="
+  ]
 ```
 
 The `nerves_hub` dependency converts key names to public keys at compile time.
@@ -216,6 +236,11 @@ change. Force it to recompile by running:
 mix deps.compile nerves_hub --force
 mix firmware
 ```
+
+While not shown here, you can export keys for safe storage. Additionally, key
+creation and firmware signing can be done outside of the `mix` tooling. The only
+part that is required is that the firmware signing public keys be added to your
+`config.exs` and to the NervesHub server.
 
 ### Publishing firmware
 

--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -35,8 +35,16 @@ defmodule NervesHub.HTTPFwupStream do
     devpath = Nerves.Runtime.KV.get("nerves_fw_devpath") || "/dev/mmcblk0"
     args = ["--apply", "--no-unmount", "-d", devpath, "--task", "upgrade"]
 
+    fwup_public_keys = NervesHub.Certificate.public_keys()
+
+    if fwup_public_keys == [] do
+      Logger.error("No fwup public keys were configured for nerves_hub.")
+      Logger.error("This means that firmware signatures are not being checked.")
+      Logger.error("nerves_hub won't allow this in the future.")
+    end
+
     args =
-      Enum.reduce(NervesHub.Certificate.public_keys(), args, fn public_key, args ->
+      Enum.reduce(fwup_public_keys, args, fn public_key, args ->
         args ++ ["--public-key", public_key]
       end)
 


### PR DESCRIPTION
I'm limited with where some firmware signing keys can be stored so I added more text to the docs to cover that use case.

I also have a check that sends error messages to the logs if `nerves_hub` detects a setup without signing keys. That's not supported, but I didn't feel ready to disable firmware updates completely if someone tries doing that.