### PR TITLE
Rename configuration keys for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ their atom name:
 
 ```elixir
 config :nerves_hub,
-  public_keys: [:devkey]
+  fwup_public_keys: [:devkey]
 ```
 
 If you have keys that cannot be stored locally, you will have to copy/paste
@@ -221,7 +221,7 @@ their public key:
 
 ```elixir
 config :nerves_hub,
-  public_keys: [
+  fwup_public_keys: [
     # devkey
     "bM/O9+ykZhCWx8uZVgx0sU3f0JJX7mqnAVU9VGeuHr4="
   ]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is the official client for devices that want to receive firmware updates fr
 ## Overview
 
 NervesHub is an open-source firmware update server that works well with
-Nerves-based devices. A managed version is available at https://nerves-hub.org
-and it's possible to host your own.
+Nerves-based devices. A managed version is available at
+[nerves-hub.org](https://nerves-hub.org) and it's possible to host your own.
 
 NervesHub provides many of the features that you'd expect in a firmware update
 server. Fundamentally, devices connect to the server either by polling at a

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,8 +19,8 @@ config :nerves_hub, NervesHub.Socket, url: "wss://0.0.0.0:4001/socket/websocket"
 
 # Device HTTP connection.
 config :nerves_hub, NervesHub.HTTPClient,
-  host: "0.0.0.0",
-  port: 4001
+  device_api_host: "0.0.0.0",
+  device_api_port: 4001
 
 # Shared Configuration.
 config :nerves_hub,

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,8 +11,8 @@ config :nerves_hub_cli,
 
 # API HTTP connection.
 config :nerves_hub_core,
-  host: "0.0.0.0",
-  port: 4002
+  api_host: "0.0.0.0",
+  api_port: 4002
 
 # Device Websocket/Channel connection.
 config :nerves_hub, NervesHub.Socket, url: "wss://0.0.0.0:4001/socket/websocket"

--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -34,7 +34,7 @@ config :nerves_firmware_ssh,
   ]
 
 config :nerves_hub,
-  public_keys: [:test]
+  fwup_public_keys: [:test]
 
 ## Uncomment for local NervesHubWeb development
 

--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -38,9 +38,9 @@ config :nerves_hub,
 
 ## Uncomment for local NervesHubWeb development
 
-# config :nerves_hub_cli, NervesHubCLI.API,
-#   host: "0.0.0.0",
-#   port: 4002
+# config :nerves_hub_core,
+#   api_host: "0.0.0.0",
+#   api_port: 4002
 
 # config :nerves_hub_cli,
 #   home: Path.expand("../.nerves-hub"),

--- a/lib/nerves_hub/certificate.ex
+++ b/lib/nerves_hub/certificate.ex
@@ -1,5 +1,11 @@
 defmodule NervesHub.Certificate do
-  @public_keys Application.get_env(:nerves_hub, :public_keys, [])
+  # Get the fwup public keys from the app environment. Support the
+  # old name of `:public_keys` for now.
+  @public_keys Application.get_env(
+                 :nerves_hub,
+                 :fwup_public_keys,
+                 Application.get_env(:nerves_hub, :public_keys, [])
+               )
                |> NervesHubCLI.resolve_fwup_public_keys()
 
   ca_cert_path =
@@ -35,7 +41,12 @@ defmodule NervesHub.Certificate do
     @ca_certs
   end
 
+  @deprecated "Use fwup_public_keys/0 instead"
   def public_keys do
+    fwup_public_keys()
+  end
+
+  def fwup_public_keys do
     @public_keys
   end
 end

--- a/lib/nerves_hub/http_client.ex
+++ b/lib/nerves_hub/http_client.ex
@@ -60,8 +60,8 @@ defmodule NervesHub.HTTPClient do
 
   defp endpoint do
     config = config()
-    host = config[:host]
-    port = config[:port]
+    host = config[:device_api_host]
+    port = config[:device_api_port]
     "https://#{host}:#{port}"
   end
 
@@ -74,6 +74,6 @@ defmodule NervesHub.HTTPClient do
   end
 
   defp config do
-    Application.get_env(:nerves_hub, __MODULE__, host: @host, port: @port)
+    Application.get_env(:nerves_hub, __MODULE__, device_api_host: @host, device_api_port: @port)
   end
 end

--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -35,7 +35,7 @@ defmodule NervesHub.HTTPFwupStream do
     devpath = Nerves.Runtime.KV.get("nerves_fw_devpath") || "/dev/mmcblk0"
     args = ["--apply", "--no-unmount", "-d", devpath, "--task", "upgrade"]
 
-    fwup_public_keys = NervesHub.Certificate.public_keys()
+    fwup_public_keys = NervesHub.Certificate.fwup_public_keys()
 
     if fwup_public_keys == [] do
       Logger.error("No fwup public keys were configured for nerves_hub.")

--- a/test/nerves_hub/certificate_test.exs
+++ b/test/nerves_hub/certificate_test.exs
@@ -22,7 +22,7 @@ defmodule NervesHub.CertificateTest do
     for cert <- certs, do: assert(is_binary(cert))
   end
 
-  test "public_keys/0" do
-    assert is_list(Certificate.public_keys())
+  test "fwup_public_keys/0" do
+    assert is_list(Certificate.fwup_public_keys())
   end
 end


### PR DESCRIPTION
This is a collection of renames on config keys. I suspect that only `public_keys` is widely used so I added a fallback and a deprecation warning for that change. The `host` to `api_host` rename doesn't really affect this project, but there were some references. That change was merged a couple weeks back to `nerves_hub_core`. The other change is to rename `host` to `device_host` for specifying the device endpoint on a NervesHub server.