### PR TITLE
Move device endpoint defaults to one place

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,11 +14,8 @@ config :nerves_hub_core,
   api_host: "0.0.0.0",
   api_port: 4002
 
-# Device Websocket/Channel connection.
-config :nerves_hub, NervesHub.Socket, url: "wss://0.0.0.0:4001/socket/websocket"
-
 # Device HTTP connection.
-config :nerves_hub, NervesHub.HTTPClient,
+config :nerves_hub,
   device_api_host: "0.0.0.0",
   device_api_port: 4001
 

--- a/lib/nerves_hub/socket.ex
+++ b/lib/nerves_hub/socket.ex
@@ -5,8 +5,6 @@ defmodule NervesHub.Socket do
 
   @cert "nerves_hub_cert"
   @key "nerves_hub_key"
-  @server_name "device.nerves-hub.org"
-  @url "wss://" <> @server_name <> "/socket/websocket"
 
   def opts(nil), do: opts([])
 
@@ -16,19 +14,22 @@ defmodule NervesHub.Socket do
     {cert_key, cert_value} = cert(user_config)
     {key_key, key_value} = key(user_config)
 
-    sni = user_config[:server_name_indication] || @server_name
-    sni = if is_binary(sni), do: to_charlist(sni), else: sni
+    server_name = Application.get_env(:nerves_hub, :device_api_host)
+    server_port = Application.get_env(:nerves_hub, :device_api_port)
+    sni = Application.get_env(:nerves_hub, :device_api_sni)
+
+    url = "wss://#{server_name}:#{server_port}/socket/websocket"
 
     socket_opts =
       [
         cacerts: ca_certs,
-        server_name_indication: sni
+        server_name_indication: to_charlist(sni)
       ]
       |> Keyword.put(cert_key, cert_value)
       |> Keyword.put(key_key, key_value)
 
     default_config = [
-      url: @url,
+      url: url,
       serializer: Jason,
       ssl_verify: :verify_peer,
       socket_opts: socket_opts

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,12 @@ defmodule NervesHub.MixProject do
 
   def application do
     [
+      env: [
+        device_api_host: "device.nerves-hub.org",
+        device_api_port: 443,
+        device_api_sni: "device.nerves-hub.org",
+        fwup_public_keys: []
+      ],
       extra_applications: [:logger]
     ]
   end

--- a/test/nerves_hub/socket_test.exs
+++ b/test/nerves_hub/socket_test.exs
@@ -7,7 +7,7 @@ defmodule NervesHub.SocketTest do
   describe "opts" do
     test "nil" do
       assert Socket.opts(nil) == [
-               url: "wss://device.nerves-hub.org/socket/websocket",
+               url: "wss://0.0.0.0:4001/socket/websocket",
                serializer: Jason,
                ssl_verify: :verify_peer,
                socket_opts: [
@@ -21,7 +21,7 @@ defmodule NervesHub.SocketTest do
 
     test "custom" do
       assert Socket.opts(cacerts: [:red]) == [
-               url: "wss://device.nerves-hub.org/socket/websocket",
+               url: "wss://0.0.0.0:4001/socket/websocket",
                serializer: Jason,
                ssl_verify: :verify_peer,
                socket_opts: [


### PR DESCRIPTION
This refactor builds on #60 to move device endpoint keys and their defaults to one place.