### PR TITLE
Simplify firmware HTTP download implementation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,7 +39,7 @@ config :nerves_runtime, Nerves.Runtime.KV.Mock, %{
   "a.nerves_fw_uuid" => "8a8b902c-d1a9-58aa-6111-04ab57c2f2a8",
   "nerves_hub_cert" => cert,
   "nerves_hub_key" => key,
-  "nerves_fw_devpath" => "/no!"
+  "nerves_fw_devpath" => "/tmp/fwup_bogus_path"
 }
 
 config :nerves_runtime, :modules, [

--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -1,15 +1,6 @@
 defmodule NervesHub.HTTPFwupStream do
   @moduledoc """
-  Handles streaming a fwupdate via HTTP.
-
-  a `callback` module is expected to be passed to `start_link/1`
-
-  messages will be recieved in the shape:
-  * `{:fwup_message, message}` - see the docs for
-    [Fwup](https://hexdocs.pm/fwup/) for more info.
-  * `{:http_error, {status_code, body}}`
-  * `{:http_error, :timeout}`
-  * `{:http_error, :too_many_redirects}`
+  Download and install a firmware update.
   """
 
   use GenServer
@@ -17,21 +8,46 @@ defmodule NervesHub.HTTPFwupStream do
   require Logger
 
   @redirect_status_codes [301, 302, 303, 307, 308]
+  @httpc_profile __MODULE__
 
+  @doc """
+  Start the downloader process
+
+  A `callback` process should be passed
+
+  Messages will be received in the shape:
+
+  * `{:fwup_message, message}` - see the docs for
+    [Fwup](https://hexdocs.pm/fwup/) for more info.
+  * `{:http_error, {status_code, body}}`
+  * `{:http_error, :timeout}`
+  * `{:http_error, :too_many_redirects}`
+  """
+  @spec start_link(pid()) :: GenServer.on_start()
   def start_link(cb) do
-    start_httpc()
     GenServer.start_link(__MODULE__, [cb])
   end
 
+  @doc """
+  Stop the downloader
+  """
+  @spec stop(GenServer.server()) :: :ok
   def stop(pid) do
     GenServer.stop(pid)
   end
 
+  @doc """
+  Download and install the firmware at the specified URL
+  """
+  @spec get(GenServer.server(), String.t()) :: :ok
   def get(pid, url) do
     GenServer.call(pid, {:get, url}, :infinity)
   end
 
+  @impl true
   def init([cb]) do
+    start_httpc()
+
     devpath = Nerves.Runtime.KV.get("nerves_fw_devpath") || "/dev/mmcblk0"
     args = ["--apply", "--no-unmount", "-d", devpath, "--task", "upgrade"]
 
@@ -54,10 +70,6 @@ defmodule NervesHub.HTTPFwupStream do
      %{
        url: nil,
        callback: cb,
-       content_length: 0,
-       buffer: "",
-       buffer_size: 0,
-       filename: "",
        caller: nil,
        number_of_redirects: 0,
        timeout: 15000,
@@ -65,22 +77,95 @@ defmodule NervesHub.HTTPFwupStream do
      }}
   end
 
+  @impl true
   def terminate(:normal, state) do
     GenServer.stop(state.fwup, :normal)
+    :inets.stop(:httpc, @httpc_profile)
     :noop
   end
 
+  @impl true
   def terminate({:error, reason}, state) do
     state.caller && GenServer.reply(state.caller, reason)
     state.callback && send(state.callback, reason)
     GenServer.stop(state.fwup, :normal)
+    :inets.stop(:httpc, @httpc_profile)
   end
 
-  def handle_call({:get, _url}, _from, %{number_of_redirects: n} = s) when n > 5 do
-    {:stop, {:error, {:http_error, :too_many_redirects}}, s}
-  end
-
+  @impl true
   def handle_call({:get, url}, from, s) do
+    make_request(url)
+
+    {:noreply, %{s | url: url, caller: from}}
+  end
+
+  @impl true
+  def handle_info({:http, {_, :stream_start, headers}}, s) do
+    Logger.debug("Stream Start: #{inspect(headers)}")
+
+    {:noreply, s}
+  end
+
+  @impl true
+  def handle_info({:http, {_, :stream, data}}, s) do
+    Fwup.send_chunk(s.fwup, data)
+    {:noreply, s, s.timeout}
+  end
+
+  @impl true
+  def handle_info({:http, {_, :stream_end, _headers}}, s) do
+    Logger.debug("Stream End")
+    GenServer.reply(s.caller, :ok)
+    {:noreply, %{s | url: nil}}
+  end
+
+  @impl true
+  def handle_info({:http, {_ref, {{_, status_code, _}, headers, body}}}, s)
+      when status_code in @redirect_status_codes do
+    Logger.debug("Redirect")
+
+    case get_header(headers, 'location') do
+      nil ->
+        {:stop, {:http_error, {status_code, body}}, s}
+
+      next_url ->
+        if s.number_of_redirects < 5 do
+          make_request(next_url)
+          {:noreply, %{s | number_of_redirects: s.number_of_redirects + 1}}
+        else
+          {:stop, {:error, {:http_error, :too_many_redirects}}, s}
+        end
+    end
+  end
+
+  @impl true
+  def handle_info({:http, {_ref, {{_, status_code, _}, _headers, body}}}, s) do
+    Logger.error("Error: #{status_code} #{inspect(body)}")
+    {:stop, {:error, {:http_error, {status_code, body}}}, s}
+  end
+
+  @impl true
+  def handle_info(:timeout, s) do
+    Logger.error("Error: timeout")
+    {:stop, {:error, {:http_error, :timeout}}, s}
+  end
+
+  defp start_httpc() do
+    :inets.start(:httpc, profile: @httpc_profile)
+
+    # Only one download is attempted. There is no need
+    # for multiple sessions, keeping the connection up
+    # after completion, etc.
+    httpc_opts = [
+      max_sessions: 1,
+      max_keep_alive_length: 1,
+      keep_alive_timeout: 0
+    ]
+
+    :httpc.set_options(httpc_opts, @httpc_profile)
+  end
+
+  defp make_request(url) do
     headers = [
       {'Content-Type', 'application/octet-stream'}
     ]
@@ -90,99 +175,14 @@ defmodule NervesHub.HTTPFwupStream do
 
     :httpc.request(
       :get,
-      {String.to_charlist(url), headers},
+      {to_charlist(url), headers},
       http_opts,
       opts,
-      :nerves_hub_fwup_stream
+      @httpc_profile
     )
-
-    {:noreply, %{s | url: url, caller: from}}
   end
 
-  def handle_info({:http, {_, :stream_start, headers}}, s) do
-    Logger.debug("Stream Start: #{inspect(headers)}")
-
-    content_length =
-      case Enum.find(headers, fn {key, _} -> key == 'content-length' end) do
-        nil ->
-          0
-
-        {_, content_length} ->
-          {content_length, _} =
-            content_length
-            |> to_string()
-            |> Integer.parse()
-
-          content_length
-      end
-
-    filename =
-      case Enum.find(headers, fn {key, _} -> key == 'content-disposition' end) do
-        nil ->
-          Path.basename(s.url)
-
-        {_, filename} ->
-          filename
-          |> to_string
-          |> String.split(";")
-          |> List.last()
-          |> String.trim()
-          |> String.trim("filename=")
-      end
-
-    {:noreply, %{s | content_length: content_length, filename: filename}}
-  end
-
-  def handle_info({:http, {_, :stream, data}}, s) do
-    Fwup.send_chunk(s.fwup, data)
-    {:noreply, s, s.timeout}
-  end
-
-  def handle_info({:http, {_, :stream_end, _headers}}, s) do
-    Logger.debug("Stream End")
-    GenServer.reply(s.caller, {:ok, s.buffer})
-    {:noreply, %{s | filename: "", content_length: 0, buffer: "", buffer_size: 0, url: nil}}
-  end
-
-  def handle_info({:http, {_ref, {{_, status_code, _}, headers, body}}}, s)
-      when status_code in @redirect_status_codes do
-    Logger.debug("Redirect")
-
-    case Enum.find(headers, fn {key, _} -> key == 'location' end) do
-      {'location', next_url} ->
-        handle_call({:get, List.to_string(next_url)}, s.caller, %{
-          s
-          | buffer: "",
-            buffer_size: 0,
-            number_of_redirects: s.number_of_redirects + 1
-        })
-
-      _ ->
-        {:stop, {:http_error, {status_code, body}}, s}
-    end
-  end
-
-  def handle_info({:http, {_ref, {{_, status_code, _}, _headers, body}}}, s) do
-    Logger.error("Error: #{status_code} #{inspect(body)}")
-    {:stop, {:error, {:http_error, {status_code, body}}}, s}
-  end
-
-  def handle_info(:timeout, s) do
-    Logger.error("Error: timeout")
-    {:stop, {:error, {:http_error, :timeout}}, s}
-  end
-
-  defp start_httpc() do
-    :inets.start(:httpc, profile: :nerves_hub_fwup_stream)
-
-    opts = [
-      max_sessions: 8,
-      max_keep_alive_length: 4,
-      max_pipeline_length: 4,
-      keep_alive_timeout: 120_000,
-      pipeline_timeout: 60_000
-    ]
-
-    :httpc.set_options(opts, :nerves_hub_fwup_stream)
+  def get_header(headers, key) do
+    Enum.find_value(headers, fn {k, v} -> k == key && v end)
   end
 end


### PR DESCRIPTION
This PR only applies to the last commit, but for ease of working with the code, I have it sequenced after other PRs. 

I'd like to make a more structural change to how firmware is downloaded, but before I did that, I wanted to trim the current implementation down. The idea is to make the bigger change easier.