### PR TITLE
Pass all firmware metadata to server when connecting

### DIFF
--- a/lib/nerves_hub/firmware_channel.ex
+++ b/lib/nerves_hub/firmware_channel.ex
@@ -18,7 +18,7 @@ defmodule NervesHub.FirmwareChannel do
   end
 
   def join_params do
-    %{}
+    Nerves.Runtime.KV.get_all_active()
   end
 
   def init(opts) do

--- a/lib/nerves_hub/http_client.ex
+++ b/lib/nerves_hub/http_client.ex
@@ -64,10 +64,15 @@ defmodule NervesHub.HTTPClient do
   end
 
   defp headers do
-    [
-      {"Content-Type", "application/json"},
-      {"X-NervesHub-Dn", Nerves.Runtime.KV.get("nerves_serial_number")},
-      {"X-NervesHub-Uuid", Nerves.Runtime.KV.get_active("nerves_fw_uuid")}
-    ]
+    headers = [{"Content-Type", "application/json"}]
+
+    Nerves.Runtime.KV.get_all_active()
+    |> Enum.reduce(headers, fn
+      {"nerves_fw_" <> key, value}, headers ->
+        [{"X-NervesHub-" <> key, value} | headers]
+
+      _, headers ->
+        headers
+    end)
   end
 end


### PR DESCRIPTION
This will take everything from `Nerves.Runtime.KV.get_active` and pass it to the server through the channel join params or the http request headers when connecting to the server.