### PR TITLE
Device channel

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,50 +23,8 @@ config :nerves_hub,
 config :nerves_hub,
   ca_certs: Path.expand("../test/fixtures/ca_certs", __DIR__)
 
-# nerves_runtime needs to disable
-# and mock out some parts.
-
-# cert =
-#   if File.exists?("./nerves-hub/test-cert.pem"),
-#     do: File.read!("./nerves-hub/test-cert.pem")
-
-# key =
-#   if File.exists?("./nerves-hub/test-key.pem"),
-#     do: File.read!("./nerves-hub/test-key.pem")
-
-config :nerves_runtime, Nerves.Runtime.KV.Mock, %{
-  "nerves_fw_active" => "a",
-  "a.nerves_fw_uuid" => "8a8b902c-d1a9-58aa-6111-04ab57c2f2a8",
-  "a.nerves_fw_product" => "nerves_hub",
-  "a.nerves_fw_architecture" => "x86_64",
-  "a.nerves_fw_version" => "0.1.0",
-  "a.nerves_fw_platform" => "x86_84",
-  "a.nerves_fw_misc" => "extra comments",
-  "a.nerves_fw_description" => "test firmware",
-  # "nerves_hub_cert" => cert,
-  # "nerves_hub_key" => key,
-  "nerves_fw_devpath" => "/tmp/fwup_bogus_path"
-}
-
-config :nerves_runtime, :modules, [
-  {Nerves.Runtime.KV, Nerves.Runtime.KV.Mock}
-]
-
 config :nerves_runtime, :kernel, autoload_modules: false
 
 config :nerves_runtime, target: "host"
 
-case Mix.env() do
-  :dev ->
-    config :mix_test_watch,
-      clear: true
-
-  :test ->
-    config :nerves_hub,
-      client: NervesHub.ClientMock,
-      http_client: NervesHub.HTTPClient.Mock,
-      rejoin_after: 0
-
-  :prod ->
-    :ok
-end
+import_config("#{Mix.env()}.exs")

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,34 @@
+use Mix.Config
+
+config :mix_test_watch,
+  clear: true
+
+# nerves_runtime needs to disable
+# and mock out some parts.
+
+cert =
+  if File.exists?("./nerves-hub/test-cert.pem"),
+    do: File.read!("./nerves-hub/test-cert.pem")
+
+key =
+  if File.exists?("./nerves-hub/test-key.pem"),
+    do: File.read!("./nerves-hub/test-key.pem")
+
+config :nerves_runtime, Nerves.Runtime.KV.Mock, %{
+  "nerves_fw_active" => "a",
+  "a.nerves_fw_uuid" => "8a8b902c-d1a9-58aa-6111-04ab57c2f2a8",
+  "a.nerves_fw_product" => "nerves_hub",
+  "a.nerves_fw_architecture" => "x86_64",
+  "a.nerves_fw_version" => "0.1.0",
+  "a.nerves_fw_platform" => "x86_84",
+  "a.nerves_fw_misc" => "extra comments",
+  "a.nerves_fw_description" => "test firmware",
+  "nerves_hub_cert" => cert,
+  "nerves_hub_key" => key,
+  "nerves_fw_devpath" => "/tmp/fwup_bogus_path",
+  "nerves_serial_number" => "test"
+}
+
+config :nerves_runtime, :modules, [
+  {Nerves.Runtime.KV, Nerves.Runtime.KV.Mock}
+]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,6 @@
+use Mix.Config
+
+config :nerves_hub,
+  client: NervesHub.ClientMock,
+  http_client: NervesHub.HTTPClient.Mock,
+  rejoin_after: 0

--- a/lib/nerves_hub/supervisor.ex
+++ b/lib/nerves_hub/supervisor.ex
@@ -1,7 +1,8 @@
 defmodule NervesHub.Supervisor do
   use Supervisor
 
-  alias NervesHub.FirmwareChannel
+  alias NervesHub.Channel
+  alias PhoenixClient.Socket
 
   @moduledoc """
   Supervisor for maintaining a channel connection to a NervesHub server
@@ -43,8 +44,8 @@ defmodule NervesHub.Supervisor do
       |> NervesHub.Socket.opts()
 
     children = [
-      {PhoenixClient.Socket, {socket_opts, [name: PhoenixClient.Socket]}},
-      {FirmwareChannel, [socket: PhoenixClient.Socket]}
+      {Socket, {socket_opts, [name: Socket]}},
+      {Channel, [socket: Socket, topic: "device"]}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/test/nerves_hub/channel_test.exs
+++ b/test/nerves_hub/channel_test.exs
@@ -1,27 +1,22 @@
-defmodule NervesHub.FirmwareChannelTest do
+defmodule NervesHub.ChannelTest do
   use ExUnit.Case, async: true
-  alias NervesHub.{ClientMock, FirmwareChannel}
+  alias NervesHub.{ClientMock, Channel}
   alias PhoenixClient.Message
 
-  doctest FirmwareChannel
+  doctest Channel
 
   setup context, do: Mox.verify_on_exit!(context)
-
-  test "topic/0" do
-    fw_uuid = Nerves.Runtime.KV.get_active("nerves_fw_uuid")
-    assert FirmwareChannel.topic() == "firmware:#{fw_uuid}"
-  end
 
   describe "handle_in/3 - update" do
     test "no firmware url" do
       Mox.expect(ClientMock, :update_available, 0, fn _ -> :ok end)
-      assert FirmwareChannel.handle_info(%Message{event: "update"}, %{}) == {:noreply, %{}}
+      assert Channel.handle_info(%Message{event: "update"}, %{}) == {:noreply, %{}}
     end
 
     test "firmware url - apply" do
       Mox.expect(ClientMock, :update_available, fn _ -> :apply end)
 
-      assert FirmwareChannel.handle_info(
+      assert Channel.handle_info(
                %Message{event: "update", payload: %{"firmware_url" => ""}},
                %{}
              ) == {:noreply, %{}}
@@ -30,7 +25,7 @@ defmodule NervesHub.FirmwareChannelTest do
     test "firmware url - ignore" do
       Mox.expect(ClientMock, :update_available, fn _ -> :ignore end)
 
-      assert FirmwareChannel.handle_info(
+      assert Channel.handle_info(
                %Message{event: "update", payload: %{"firmware_url" => ""}},
                %{}
              ) == {:noreply, %{}}
@@ -41,23 +36,23 @@ defmodule NervesHub.FirmwareChannelTest do
       Mox.expect(ClientMock, :update_available, fn _ -> {:reschedule, 999} end)
 
       assert {:noreply, state} =
-               FirmwareChannel.handle_info(%Message{event: "update", payload: data}, %{})
+               Channel.handle_info(%Message{event: "update", payload: data}, %{})
 
       Mox.expect(ClientMock, :update_available, fn _ -> {:reschedule, 1} end)
 
       assert {:noreply, %{} = state} =
-               FirmwareChannel.handle_info(%Message{event: "update", payload: data}, state)
+               Channel.handle_info(%Message{event: "update", payload: data}, state)
 
       assert_receive {:update_reschedule, ^data}
     end
 
     test "catch all" do
-      assert FirmwareChannel.handle_info(:any, :state) == {:noreply, :state}
+      assert Channel.handle_info(:any, :state) == {:noreply, :state}
     end
   end
 
   test "handle_close" do
-    assert FirmwareChannel.handle_info(%Message{event: "phx_close", payload: %{}}, :state) ==
+    assert Channel.handle_info(%Message{event: "phx_close", payload: %{}}, :state) ==
              {:noreply, :state}
 
     assert_receive :join
@@ -67,32 +62,32 @@ defmodule NervesHub.FirmwareChannelTest do
     test "fwup" do
       message = {:ok, 1, "message"}
       Mox.expect(ClientMock, :handle_fwup_message, fn ^message -> :ok end)
-      assert FirmwareChannel.handle_info({:fwup, message}, %{}) == {:noreply, %{}}
+      assert Channel.handle_info({:fwup, message}, %{}) == {:noreply, %{}}
     end
 
     test "http_error" do
       error = "error"
       Mox.expect(ClientMock, :handle_error, fn ^error -> :apply end)
-      assert FirmwareChannel.handle_info({:http_error, error}, %{}) == {:noreply, %{}}
+      assert Channel.handle_info({:http_error, error}, %{}) == {:noreply, %{}}
     end
 
     test "update_reschedule" do
       data = %{"firmware_url" => ""}
       Mox.expect(ClientMock, :update_available, fn ^data -> :apply end)
-      assert FirmwareChannel.handle_info({:update_reschedule, data}, %{}) == {:noreply, %{}}
+      assert Channel.handle_info({:update_reschedule, data}, %{}) == {:noreply, %{}}
     end
   end
 
   describe "handle_info - down" do
     test "normal" do
-      assert FirmwareChannel.handle_info({:DOWN, :any, :process, :any, :normal}, :state) ==
+      assert Channel.handle_info({:DOWN, :any, :process, :any, :normal}, :state) ==
                {:noreply, :state}
     end
 
     test "non-normal" do
       Mox.expect(ClientMock, :handle_error, 1, fn _ -> :ok end)
 
-      assert FirmwareChannel.handle_info({:DOWN, :any, :process, :any, :"non-normal"}, :state) ==
+      assert Channel.handle_info({:DOWN, :any, :process, :any, :"non-normal"}, :state) ==
                {:stop, :"non-normal", :state}
     end
   end


### PR DESCRIPTION
This PR changes the topic the device connect to from "firmware:#{firmware_uuid}" to "device".

Depends on https://github.com/nerves-hub/nerves_hub_web/pull/363