### PR TITLE
Change socket process name to prevent collision

### DIFF
--- a/lib/nerves_hub/supervisor.ex
+++ b/lib/nerves_hub/supervisor.ex
@@ -46,8 +46,8 @@ defmodule NervesHub.Supervisor do
     join_params = Nerves.Runtime.KV.get_all_active()
 
     children = [
-      {Socket, {socket_opts, [name: Socket]}},
-      {Channel, [socket: Socket, topic: "device", join_params: join_params]}
+      {Socket, {socket_opts, [name: NervesHub.Socket]}},
+      {Channel, [socket: NervesHub.Socket, topic: "device", join_params: join_params]}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)


### PR DESCRIPTION
The socket process is being applied the name `PhoenixClient.Socket` which causes problems if other applications try to start a socket process using the same name. The name should really be an atom that is associated with the project instead of the library. This PR changes it to `NervesHub.Socket`