### PR TITLE
Raise the http timeout to 60s

### DIFF
--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -72,7 +72,7 @@ defmodule NervesHub.HTTPFwupStream do
        callback: cb,
        caller: nil,
        number_of_redirects: 0,
-       timeout: 15000,
+       timeout: 60_000,
        fwup: fwup
      }}
   end


### PR DESCRIPTION
This raises the length of time to wait for data from 15 to 60 seconds.
This means that the client can receive a packet and then so long as the
next packet arrives in under a minute, it won't time out. This will be
painful, but 15 seconds hit during a training class and it did seem a
little short for what's usually going to be an unattended download.