### PR TITLE
Use socket key logic in http client

### DIFF
--- a/lib/nerves_hub/http_client.ex
+++ b/lib/nerves_hub/http_client.ex
@@ -46,7 +46,16 @@ defmodule NervesHub.HTTPClient do
 
   defp ssl_options() do
     cert = Nerves.Runtime.KV.get(@cert) |> Certificate.pem_to_der()
-    key = Nerves.Runtime.KV.get(@key) |> Certificate.pem_to_der()
+
+    key =
+      @key
+      |> Nerves.Runtime.KV.get()
+      |> X509.PrivateKey.from_pem()
+      |> case do
+        {:error, :not_found} -> <<>>
+        {:ok, decoded} -> X509.PrivateKey.to_der(decoded)
+      end
+
     sni = Application.get_env(:nerves_hub, :device_api_sni)
 
     [


### PR DESCRIPTION
Why
---

- Old http client logic failed on ec private keys

--

Long term I think it would probably make sense to have a central location where some of this logic happens so that socker&http client desyncs happen less frequently.