### PR TITLE
Account for no client key in HTTPClient

### DIFF
--- a/lib/nerves_hub/http_client.ex
+++ b/lib/nerves_hub/http_client.ex
@@ -48,12 +48,13 @@ defmodule NervesHub.HTTPClient do
     cert = Nerves.Runtime.KV.get(@cert) |> Certificate.pem_to_der()
 
     key =
-      @key
-      |> Nerves.Runtime.KV.get()
-      |> X509.PrivateKey.from_pem()
-      |> case do
-        {:error, :not_found} -> <<>>
-        {:ok, decoded} -> X509.PrivateKey.to_der(decoded)
+      with key when not is_nil(key) <- Nerves.Runtime.KV.get(@key) do
+        case X509.PrivateKey.from_pem(key) do
+          {:error, :not_found} -> <<>>
+          {:ok, decoded} -> X509.PrivateKey.to_der(decoded)
+        end
+      else
+        nil -> <<>>
       end
 
     sni = Application.get_env(:nerves_hub, :device_api_sni)


### PR DESCRIPTION
At least in test it is possible for there to be no key set in `Nerves.Runtime.KV`, account for this in the http_client code so that tests pass.