### PR TITLE
Support reboot requests from NervesHub

### DIFF
--- a/lib/nerves_hub/channel.ex
+++ b/lib/nerves_hub/channel.ex
@@ -28,6 +28,14 @@ defmodule NervesHub.Channel do
      }}
   end
 
+  def handle_info(%Message{event: "reboot"}, state) do
+    Logger.warn("Reboot Request from NervesHub")
+    Channel.push_async(state.channel, "rebooting", %{})
+    # TODO: Maybe allow delayed reboot
+    Nerves.Runtime.reboot()
+    {:noreply, state}
+  end
+
   def handle_info(%Message{event: "update", payload: params}, state) do
     {:noreply, maybe_update_firmware(params, state)}
   end


### PR DESCRIPTION
Part of https://github.com/nerves-hub/nerves_hub_web/issues/401

Allows triggering a reboot from NervesHub channel. Logs a warning message and also sends a "rebooting" message back to NervesHub as an ack of the request