### PR TITLE
Handle fw download connect timeout

### DIFF
--- a/lib/nerves_hub/channel.ex
+++ b/lib/nerves_hub/channel.ex
@@ -73,7 +73,6 @@ defmodule NervesHub.Channel do
   end
 
   def handle_info({:http_error, error}, state) do
-    Logger.error("HTTP Stream Error: #{inspect(error)}")
     _ = Client.handle_error(@client, error)
     {:noreply, state}
   end

--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -145,6 +145,12 @@ defmodule NervesHub.HTTPFwupStream do
   end
 
   @impl true
+  def handle_info({:http, {_ref, {:error, error}}}, state) do
+    Logger.error("FWUP Error: #{inspect(error)}")
+    {:stop, {:error, {:http_error, error}}, state}
+  end
+
+  @impl true
   def handle_info(:timeout, s) do
     Logger.error("Error: timeout")
     {:stop, {:error, {:http_error, :timeout}}, s}
@@ -170,7 +176,7 @@ defmodule NervesHub.HTTPFwupStream do
       {'Content-Type', 'application/octet-stream'}
     ]
 
-    http_opts = [timeout: :infinity, autoredirect: false]
+    http_opts = [connect_timeout: 30_000, timeout: :infinity, autoredirect: false]
     opts = [stream: :self, receiver: self(), sync: false]
 
     :httpc.request(

--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -146,7 +146,7 @@ defmodule NervesHub.HTTPFwupStream do
 
   @impl true
   def handle_info({:http, {_ref, {:error, error}}}, state) do
-    Logger.error("FWUP Error: #{inspect(error)}")
+    Logger.error("HTTP Stream Error: #{inspect(error)}")
     {:stop, {:error, {:http_error, error}}, state}
   end
 


### PR DESCRIPTION
While working locally I noticed that we are not handling
when a device attempts to download a file from a source it
cannot see on the network. So this adds new `handle_info/2`
clause to `HTTPFwupStream` module to handle that case.

Also, we were not setting `connect_timeout` in the request and
it defaults to `timeout`, which is `:inifinity`. So time to crash
for this case was varying (60 sec - 30 min in some cases). So
this also adds a `connect_timeout: 30_000` to the download request
so we can fail quicker if we can't even connect to the download host.