### PR TITLE
Push fwup progress through channel

### DIFF
--- a/lib/nerves_hub/channel.ex
+++ b/lib/nerves_hub/channel.ex
@@ -68,6 +68,14 @@ defmodule NervesHub.Channel do
   end
 
   def handle_info({:fwup, message}, state) do
+    case message do
+      {:progress, percent} ->
+        Channel.push_async(state.channel, "fwup_progress", %{value: percent})
+
+      _ ->
+        :ok
+    end
+
     _ = Client.handle_fwup_message(@client, message)
     {:noreply, state}
   end


### PR DESCRIPTION
A simple change to push the fwup progress up the phoenix channel so NervesHub can
display it.