### PR TITLE
Decouple config value expected to be used in CLI

### DIFF
--- a/lib/nerves_hub/certificate.ex
+++ b/lib/nerves_hub/certificate.ex
@@ -6,7 +6,7 @@ defmodule NervesHub.Certificate do
                  :fwup_public_keys,
                  Application.get_env(:nerves_hub, :public_keys, [])
                )
-               |> NervesHubCLI.resolve_fwup_public_keys()
+               |> NervesHubCLI.resolve_fwup_public_keys(Application.get_env(:nerves_hub, :org))
 
   ca_cert_path =
     System.get_env("NERVES_HUB_CA_CERTS") || Application.get_env(:nerves_hub, :ca_certs) ||


### PR DESCRIPTION
Counterpart of https://github.com/nerves-hub/nerves_hub_cli/pull/125 (will need to be merged before these tests will pass)

Simple change to make this library more explicitly in charge of config values. Previously, this would be looked up in NervesHubCLI when resolving fwup public keys for this library. With this change, this config value only matters in the context of this lib.