### PR TITLE
Allow using RingLogger with remote iex

### DIFF
--- a/lib/nerves_hub/console_channel.ex
+++ b/lib/nerves_hub/console_channel.ex
@@ -204,7 +204,7 @@ defmodule NervesHub.ConsoleChannel do
         io_request(from, reply_as, req, %{state | retry_count: state.retry_count + 1})
     end
 
-    %{state | request: {from, reply_as, req}, retry_count: 0}
+    %{state | retry_count: 0}
   end
 
   defp io_request(_, _, req, state) do


### PR DESCRIPTION
Fixes https://github.com/nerves-hub/nerves_hub/issues/106

Performing `RingLogger.attach` would link the RingLogger to the running IEx process and send its own `:put_chars` events to display to the remote console. However, we store the details of each IO event in order to have the `from` pid and `reply_as` reference so we know where to send any IO reply to. But introducing a new IO process sending requests throws things out of sync.

We automatically reply to `:put_chars` request with `:ok` (as defined in the docs) so we don't need to keep its request details in the state. Instead, we can focus on just storing `from` and `reply_as` for `:get_line` events since thats the message to which the IO requires us to send user input to.

I tested this locally and works 👌 
![image](https://user-images.githubusercontent.com/11321326/59300564-b8f55600-8c4c-11e9-8f77-f9c09b84d203.png)
