### PR TITLE
Fix deleting timer key

### DIFF
--- a/lib/nerves_hub/channel.ex
+++ b/lib/nerves_hub/channel.ex
@@ -143,6 +143,6 @@ defmodule NervesHub.Channel do
       Process.cancel_timer(timer)
     end
 
-    Map.delete(state, :key)
+    Map.delete(state, key)
   end
 end

--- a/test/nerves_hub/channel_test.exs
+++ b/test/nerves_hub/channel_test.exs
@@ -46,6 +46,18 @@ defmodule NervesHub.ChannelTest do
       assert_receive {:update_reschedule, ^data}
     end
 
+    test "firmware url - removes existing timer" do
+      data = %{"firmware_url" => ""}
+      Mox.expect(ClientMock, :update_available, fn _ -> :ignore end)
+
+      assert {:noreply, state} =
+               Channel.handle_info(%Message{event: "update", payload: data}, %{
+                 update_reschedule_timer: nil
+               })
+
+      refute Map.has_key?(state, :update_reschedule_timer)
+    end
+
     test "catch all" do
       assert Channel.handle_info(:any, :state) == {:noreply, :state}
     end


### PR DESCRIPTION
I noticed that after canceling a timer, we don't actually remove it from the state because of a typo. So this fixes that.