### PR TITLE
Don't link to HTTPFwupStream process

### DIFF
--- a/lib/nerves_hub/channel.ex
+++ b/lib/nerves_hub/channel.ex
@@ -119,7 +119,7 @@ defmodule NervesHub.Channel do
     # to control exactly when an update is applied.
     case Client.update_available(@client, data) do
       :apply ->
-        {:ok, http} = HTTPFwupStream.start_link(self())
+        {:ok, http} = HTTPFwupStream.start(self())
         spawn_monitor(HTTPFwupStream, :get, [http, url])
         Logger.info("[NervesHub] Downloading firmware: #{url}")
         state

--- a/lib/nerves_hub/http_fwup_stream.ex
+++ b/lib/nerves_hub/http_fwup_stream.ex
@@ -28,6 +28,11 @@ defmodule NervesHub.HTTPFwupStream do
     GenServer.start_link(__MODULE__, [cb])
   end
 
+  @spec start(pid()) :: GenServer.on_start()
+  def start(cb) do
+    GenServer.start(__MODULE__, [cb])
+  end
+
   @doc """
   Stop the downloader
   """


### PR DESCRIPTION
Resolves https://github.com/nerves-hub/nerves_hub/issues/95

Changes the connection to HTTPFwupStream to just `start` it instead of linking the process. With the link, if the HTTPFwup stream crashes, the whole Channel genserver also restarts which forces it to rejoin NervesHub, creating a duplicate Phoenix channel that needs to be cleaned up. This lets us instead keep the channel open and all state with it instead of needlessly restarting.